### PR TITLE
Feature/cloud 179 variant UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This repository holds all helm charts that are used by DevOps
 
 To import the chart repository, do
 
-`helm repo add variant-in-helm-charts https://variant-inc.github.io/lazy-helm-charts/`
+`helm repo add variant-inc-helm-charts https://variant-inc.github.io/lazy-helm-charts/`

--- a/README.md
+++ b/README.md
@@ -7,3 +7,55 @@ This repository holds all helm charts that are used by DevOps
 To import the chart repository, do
 
 `helm repo add variant-inc-helm-charts https://variant-inc.github.io/lazy-helm-charts/`
+
+## Using a lazy-helm-chart as a Subchart
+
+### Chart.yaml
+
+```yaml
+apiVersion: v2
+name: coolapi
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 1.16.0
+
+# Insert the chart as a dependency
+dependencies:
+- name: <<Chart Name>>
+  version: "0.2.0" #Version to use of the subchart
+  repository: "https://variant-inc.github.io/lazy-helm-charts/"
+```
+
+### values.yaml
+
+```yaml
+# In your parent chart insert the name of the subchart as it's values' key
+<<Chart Name>>:
+  # Values for <<Chart Name>> goes here
+  nameOverride: "coolapi"
+  fullnameOverride: ""
+  istio:
+    enabled: true
+    ## For traffic to the cluster
+    ingress:
+      public: false
+      # # Provide only the full hostname
+      host: ops-drivevariant.com
+      # Add endpoints to be rerouted to / in public access
+      redirects: []
+      # # Should the endpoint be external or internal
+      backend:
+        service:
+          name: '{{ include "chart.fullname" . }}'
+          ## port should be number
+          port: "{{ .Values.global.port }}"
+```
+
+### Pull the depency chart and Install
+
+`helm dependency update`
+
+`helm template coolapi  . -n cool-test --values values.yaml`
+
+`helm install coolapi  . -n cool-test --values values.yaml --render-subchart-notes`

--- a/charts/variant-api/.helmignore
+++ b/charts/variant-api/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: variant-service-deployments
+name: variant-api
 description: A Helm chart for Istio Objects
 
-version: 0.1.5
+version: 1.0.0
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/
@@ -12,3 +12,5 @@ sources:
 maintainers:
   - name: vibindaniel
     email: vibind@drivevariant.com
+  - name: samiralyateem
+    email: samira@drivevariant.com

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -15,7 +15,9 @@ and then install the chart using
 
 ### Standard URL Prefix
 
-When using Istio ingress, the standard url schema {HOST}/{NAMESPACE}/{RELEASE_NAME}. This is a departure from the previous version that did not include a specific match url prefix. This may be a breaking change where your application may not know to redirect requests with the prefix of the url schema. See documentation about running your app/server running behind a proxy to allow proper function of your backend.
+When using Istio ingress, the standard url schema {HOST}/{NAMESPACE}/{RELEASE_NAME}.
+This is a departure from the previous version that did not include a specific match url prefix.
+This also may be a breaking change where your application may not know to redirect requests with the prefix of the url schema. See documentation about running your app/server running behind a proxy to allow proper function of your backend.
 
 ### Public vs Private Ingress
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,0 +1,24 @@
+# Variant Service Deployments Helm Chart
+
+## Install
+
+To install the chart,
+first add the repo
+
+`helm repo add variant-in-helm-charts https://variant-inc.github.io/in-helm-charts/ --password <token>`
+
+and then install the chart using
+
+`helm upgrade --install devops-services -n sample-ns -f values.yaml`
+
+## Considerations
+
+### Standard URL Prefix
+
+When using Istio ingress, the standard url schema {HOST}/{NAMESPACE}/{RELEASE_NAME}. This is a departure from the previous version that did not include a specific match url prefix. This may be a breaking change where your application may not know to redirect requests with the prefix of the url schema. See documentation about running your app/server running behind a proxy to allow proper function of your backend.
+
+### Public vs Private Ingress
+
+When not using public ingress, you can only access your Service via [VPN](https://usxtech.atlassian.net/wiki/spaces/CLOUD/pages/1332445185/How+to+configure+OpenVPN+using+Okta+SSO+to+access+USX+Variant+Resources).
+
+When using public ingess, the following URL prefixes are rerouted to the root URL and are essentially blocked. They must be accessed internally, or through VPN. You can add to this list in Values.istio.ingress.redirects.

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -8,6 +8,18 @@ https://api.internal.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace
 {{- if .Values.istio.ingress.public }}
 ....or 
 https://api.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
-for public access
+for public access.
+
+The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fullName }}
+{{- if .Values.istio.ingress.redirects}}
+{{- range .Values.istio.ingress.redirects }}
+/{{ $.Release.Namespace }}/{{ $fullName }}{{ .prefix  }}
+{{- end }}
+{{- end }}
+/{{ .Release.Namespace }}/{{ $fullName }}/health
+/{{ .Release.Namespace }}/{{ $fullName }}/docs
+/{{ .Release.Namespace }}/{{ $fullName }}/redoc
+/{{ .Release.Namespace }}/{{ $fullName }}/swagger
+/{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
 {{- end}}
 {{- end}}

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -1,0 +1,13 @@
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- if .Values.istio.ingress }}
+
+You can reach the application at through vpn-<env>-drivevariant.com
+
+https://api.internal.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
+
+{{- if .Values.istio.ingress.public }}
+....or 
+https://api.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
+for public access
+{{- end}}
+{{- end}}

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/variant-api/templates/virtual-service-public.yaml
+++ b/charts/variant-api/templates/virtual-service-public.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.istio.enabled -}}
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+{{- if .Values.istio.ingress }}
+{{- if .Values.istio.ingress.public }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}
+  labels: {{ $labels | nindent 4 }}
+spec:
+  gateways:
+    - default/default
+  hosts:
+    - api.{{ .Values.istio.ingress.host }} 
+    - api.apps.{{ .Values.istio.ingress.host }}
+  http:
+    - name: Private Path Redirects
+      match:
+      {{- if .Values.istio.ingress.redirects}}
+        {{- range .Values.istio.ingress.redirects }}
+        - uri:
+            prefix: /{{ $.Release.Namespace }}/{{ $fullName }}{{ .prefix  }}
+        {{- end }}
+      {{- end }}
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/health
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/docs
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/redoc
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swagger
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+    - name: Default Ingress
+      match:
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/variant-api/templates/virtual-service.yaml
+++ b/charts/variant-api/templates/virtual-service.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.istio.enabled -}}
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+{{- if .Values.istio.ingress }}
+---
+{{- if .Values.istio.ingress.public }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}
+  labels: {{ $labels | nindent 4 }}
+spec:
+  gateways:
+    - default/default
+  hosts:
+    - api.{{ .Values.istio.ingress.host }} 
+    - api.apps.{{ .Values.istio.ingress.host }}
+  http:
+    - name: Private Path Redirects
+      match:
+      {{- if .Values.istio.ingress.redirects}}
+        {{- range .Values.istio.ingress.redirects }}
+        - uri:
+            prefix: /{{ $.Release.Namespace }}/{{ $fullName }}{{ .prefix  }}
+        {{- end }}
+      {{- end }}
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/health
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/docs
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/redoc
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swagger
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+    - name: Default Ingress
+      match:
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+---
+{{- end -}}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}-internal
+  labels: {{ $labels | nindent 4 }}
+spec:
+  gateways:
+    - default/default
+  hosts:
+    - api.internal.{{ .Values.istio.ingress.host }}
+    - api.internal.apps.{{ .Values.istio.ingress.host }}
+  http:
+    - name: Private Ingress
+      match:
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+{{- end -}}
+{{- end -}}

--- a/charts/variant-api/templates/virtual-service.yaml
+++ b/charts/variant-api/templates/virtual-service.yaml
@@ -3,57 +3,6 @@
 {{- $labels := (include "chart.labels" .) -}}
 {{- if .Values.istio.ingress }}
 ---
-{{- if .Values.istio.ingress.public }}
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: {{ $fullName }}
-  labels: {{ $labels | nindent 4 }}
-spec:
-  gateways:
-    - default/default
-  hosts:
-    - api.{{ .Values.istio.ingress.host }} 
-    - api.apps.{{ .Values.istio.ingress.host }}
-  http:
-    - name: Private Path Redirects
-      match:
-      {{- if .Values.istio.ingress.redirects}}
-        {{- range .Values.istio.ingress.redirects }}
-        - uri:
-            prefix: /{{ $.Release.Namespace }}/{{ $fullName }}{{ .prefix  }}
-        {{- end }}
-      {{- end }}
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/health
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/docs
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/redoc
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swagger
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
-      rewrite:
-        uri: /
-      route:
-        - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
-            port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
-    - name: Default Ingress
-      match:
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/
-      rewrite:
-        uri: /
-      route:
-        - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
-            port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
----
-{{- end -}}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -10,13 +10,13 @@ istio:
   ## For traffic to the cluster
   ingress:
     # # Should the service be exposed via public ingress gateway?
-    public: false
+    public: true
     # # Provide only the full hostname
     host: ops-drivevariant.com
 
     # Add endpoints to be rerouted to / in public access
-    redirects: []
-      # - prefix: /health
+    redirects:
+      - prefix: /hidden
     # # Should the endpoint be external or internal
     backend:
       service:

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -2,21 +2,31 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-nameOverride:
-fullnameOverride:
+nameOverride: ""
+fullnameOverride: ""
 
 istio:
   enabled: false
   ## For traffic to the cluster
   ingress:
+    # # Should the service be exposed via public ingress gateway?
+    public: false
     # # Provide only the full hostname
-    # host: "test.example.com"
+    host: ops-drivevariant.com
+
+    # Add endpoints to be rerouted to / in public access
+    redirects: []
+      # - prefix: /health
     # # Should the endpoint be external or internal
-    # backend:
-    #   service:
-    #     name: test
-    #     ## port should be number
-    #     port: 1234
+    backend:
+      service:
+        ## These values can be template variables
+        # name: {{ .Values.ReleaseName }}
+        # port: {{ .Global.service.port }}
+        name: test
+        ## port should be number
+        port: 1234
+        
 
   ## For external traffic
   egress:
@@ -39,3 +49,4 @@ serviceMonitor:
   scrapeTimeout: 10s
   # any label selector
   selector: {}
+  

--- a/charts/variant-service-deployments/Chart.yaml
+++ b/charts/variant-service-deployments/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: variant-service-deployments
-description: A Helm chart for Istio Objects
+name: variant-ui
+description: A Helm chart for a web UI configuration
 
-version: 0.1.5
+version: 1.0.0
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/
@@ -12,3 +12,5 @@ sources:
 maintainers:
   - name: vibindaniel
     email: vibind@drivevariant.com
+  - name: salyateem13
+    email: samira@drivevariant.com

--- a/charts/variant-service-deployments/Chart.yaml
+++ b/charts/variant-service-deployments/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-service-deployments
 description: A Helm chart for Istio Objects
 
-version: 0.1.5
+version: 0.2.0
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-service-deployments/templates/NOTES.txt
+++ b/charts/variant-service-deployments/templates/NOTES.txt
@@ -1,6 +1,8 @@
 {{- if .Values.ingress }}
 
-You can reach the application at
+You can reach the application at the following hosts
 
-https://{{ .Values.ingress.host }}
+{{- range .Values.istio.ingress.hosts }}
+- https://{{ tpl .url $ | quote }}
+{{- end }}
 {{- end}}

--- a/charts/variant-service-deployments/templates/virtual-service.yaml
+++ b/charts/variant-service-deployments/templates/virtual-service.yaml
@@ -12,12 +12,73 @@ spec:
   gateways:
     - default/default
   hosts:
-    - {{ tpl .Values.istio.ingress.host $ | quote }}
+    {{- if .Values.istio.ingress.env }}
+    - api.{{ .Values.istio.ingress.env }}-{{ .Values.istio.ingress.host }}
+    {{- else }}
+    - api.{{ .Values.istio.ingress.host }}
+    {{- end }}
   http:
-    - route:
+    - name: Default
+      route:
         - destination:
             host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
             port:
               number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+    - name: Private Path Redirects
+      match:
+        {{- range .Values.istio.ingress.redirects }}
+        - uri:
+            prefix: /{{ $.Release.Namespace }}/{{ $fullName }}{{ .prefix  }}
+        {{- end }}
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/docs
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/redoc
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swagger
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+    - name: Default Ingress
+      match:
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}-internal
+  labels: {{ $labels | nindent 4 }}
+spec:
+  gateways:
+    - default/default
+  hosts:
+    {{- if .Values.istio.ingress.env }}
+    - api.internal.{{ .Values.istio.ingress.env }}-{{ .Values.istio.ingress.host }}
+    {{- else }}
+    - api.internal.{{ .Values.istio.ingress.host }}
+    {{- end }}
+  http:
+    - name: Private Ingress
+      match:
+        - uri:
+            prefix: /{{ .Release.Namespace }}/{{ $fullName }}
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+---
 {{- end -}}
 {{- end -}}

--- a/charts/variant-service-deployments/templates/virtual-service.yaml
+++ b/charts/variant-service-deployments/templates/virtual-service.yaml
@@ -12,7 +12,9 @@ spec:
   gateways:
     - default/default
   hosts:
-    - {{ tpl .Values.istio.ingress.host $ | quote }}
+  {{- range .Values.istio.ingress.hosts }}
+    - {{ tpl .url $ | quote }}
+  {{- end }}
   http:
     - route:
         - destination:

--- a/charts/variant-service-deployments/templates/virtual-service.yaml
+++ b/charts/variant-service-deployments/templates/virtual-service.yaml
@@ -12,73 +12,12 @@ spec:
   gateways:
     - default/default
   hosts:
-    {{- if .Values.istio.ingress.env }}
-    - api.{{ .Values.istio.ingress.env }}-{{ .Values.istio.ingress.host }}
-    {{- else }}
-    - api.{{ .Values.istio.ingress.host }}
-    {{- end }}
+    - {{ tpl .Values.istio.ingress.host $ | quote }}
   http:
-    - name: Default
-      route:
+    - route:
         - destination:
             host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
             port:
               number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
-    - name: Private Path Redirects
-      match:
-        {{- range .Values.istio.ingress.redirects }}
-        - uri:
-            prefix: /{{ $.Release.Namespace }}/{{ $fullName }}{{ .prefix  }}
-        {{- end }}
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/docs
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/redoc
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swagger
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
-      rewrite:
-        uri: /
-      route:
-        - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
-            port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
-    - name: Default Ingress
-      match:
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}
-      route:
-        - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
-            port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
----
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: {{ $fullName }}-internal
-  labels: {{ $labels | nindent 4 }}
-spec:
-  gateways:
-    - default/default
-  hosts:
-    {{- if .Values.istio.ingress.env }}
-    - api.internal.{{ .Values.istio.ingress.env }}-{{ .Values.istio.ingress.host }}
-    {{- else }}
-    - api.internal.{{ .Values.istio.ingress.host }}
-    {{- end }}
-  http:
-    - name: Private Ingress
-      match:
-        - uri:
-            prefix: /{{ .Release.Namespace }}/{{ $fullName }}
-      route:
-        - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
-            port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
----
 {{- end -}}
 {{- end -}}

--- a/charts/variant-service-deployments/values.yaml
+++ b/charts/variant-service-deployments/values.yaml
@@ -6,17 +6,22 @@ nameOverride:
 fullnameOverride:
 
 istio:
-  enabled: false
+  enabled: true
   ## For traffic to the cluster
   ingress:
     # # Provide only the full hostname
-    # host: "test.example.com"
+    host: drivevariant.com
+    env: ops
+
+    # Add endpoints to be rerouted to / in public access
+    redirects:
+      - prefix: /health
     # # Should the endpoint be external or internal
-    # backend:
-    #   service:
-    #     name: test
-    #     ## port should be number
-    #     port: 1234
+    backend:
+      service:
+        name: test
+        ## port should be number
+        port: 1234
 
   ## For external traffic
   egress:

--- a/charts/variant-service-deployments/values.yaml
+++ b/charts/variant-service-deployments/values.yaml
@@ -10,7 +10,9 @@ istio:
   ## For traffic to the cluster
   ingress:
     # # Provide only the full hostname
-    # host: "test.example.com"
+    # hosts: 
+    #   - url: "test.example.com"
+    #   - url: "test.other.com"
     # # Should the endpoint be external or internal
     # backend:
     #   service:


### PR DESCRIPTION
To test, cd variant-ui chart and edit the values.yaml to enable istio. Configure the hosts and backend, and install the chart.

`helm install test-release . -n test --create-namespace`

Confirm install of chart with multiple host names.