### PR TITLE
Feature/cloud 260 internal UI vs

### DIFF
--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.0.0
+version: 1.0.1
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/templates/_helpers.tpl
+++ b/charts/variant-ui/templates/_helpers.tpl
@@ -49,3 +49,25 @@ Selector labels
 app.kubernetes.io/name: {{ include "chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Internal Hosts
+*/}}
+{{- define "chart.internalHosts" -}}
+{{- range .Values.istio.ingress.hosts }}
+{{- if contains "internal" .url }}
+    - {{ .url }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Public Hosts
+*/}}
+{{- define "chart.publicHosts" -}}
+{{- range .Values.istio.ingress.hosts }}
+{{- if contains "internal" .url | not }}
+    - {{ .url }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/variant-ui/templates/virtual-service-public.yaml
+++ b/charts/variant-ui/templates/virtual-service-public.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.istio.enabled -}}
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+{{- $publicHosts := (include "chart.publicHosts" .) -}}
+{{- if .Values.istio.ingress }}
+{{- if empty $publicHosts | not}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}
+  labels: {{ $labels | nindent 4 }}
+spec:
+  gateways:
+    - default/default
+  hosts: {{ $publicHosts }}
+  http:
+    - name: Private Path Redirects
+      match:
+      {{- if .Values.istio.ingress.redirects}}
+        {{- range .Values.istio.ingress.redirects }}
+        - uri:
+            prefix: {{ .prefix  }}
+        {{- end }}
+      {{- end }}
+        - uri:
+            prefix: /health
+        - uri:
+            prefix: /healthz
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+    - name: Default Ingress
+      route:
+        - destination:
+            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            port:
+              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/variant-ui/templates/virtual-service.yaml
+++ b/charts/variant-ui/templates/virtual-service.yaml
@@ -8,7 +8,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-internal
   labels: {{ $labels | nindent 4 }}
 spec:
   gateways:

--- a/charts/variant-ui/templates/virtual-service.yaml
+++ b/charts/variant-ui/templates/virtual-service.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.istio.enabled -}}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
+{{- $internalHosts := (include "chart.internalHosts" .) -}}
 {{- if .Values.istio.ingress }}
+{{- if empty $internalHosts | not}}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -11,15 +13,13 @@ metadata:
 spec:
   gateways:
     - default/default
-  hosts:
-  {{- range .Values.istio.ingress.hosts }}
-    - {{ tpl .url $ | quote }}
-  {{- end }}
+  hosts: {{ $internalHosts }}
   http:
     - route:
         - destination:
             host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
             port:
               number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -10,9 +10,9 @@ istio:
   ## For traffic to the cluster
   ingress:
     # Provide only the full hostname
-    hosts: 
-      - url: "release.apps.dev-drivevariant.com"
-      - url: "release.internal.apps.dev-drivevariant.com"
+    hosts: []
+      # - url: "release.apps.dev-drivevariant.com"
+      # - url: "release.internal.apps.dev-drivevariant.com"
     # Add endpoints to be rerouted to / in public access
     redirects:
       - prefix: /hidden

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -6,12 +6,11 @@ nameOverride:
 fullnameOverride:
 
 istio:
-  enabled: true
+  enabled: false
   ## For traffic to the cluster
   ingress:
     # Provide only the full hostname
     hosts: 
-      - url: "release.internal.apps.dev-drivevariant.com"
       - url: "release.apps.dev-drivevariant.com"
       - url: "release.internal.apps.dev-drivevariant.com"
     # Add endpoints to be rerouted to / in public access

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -6,19 +6,22 @@ nameOverride:
 fullnameOverride:
 
 istio:
-  enabled: false
+  enabled: true
   ## For traffic to the cluster
   ingress:
-    # # Provide only the full hostname
-    # hosts: 
-    #   - url: "test.example.com"
-    #   - url: "test.other.com"
-    # # Should the endpoint be external or internal
-    # backend:
-    #   service:
-    #     name: test
-    #     ## port should be number
-    #     port: 1234
+    # Provide only the full hostname
+    hosts: 
+      - url: "release.internal.apps.dev-drivevariant.com"
+      - url: "release.apps.dev-drivevariant.com"
+      - url: "release.internal.apps.dev-drivevariant.com"
+    # Add endpoints to be rerouted to / in public access
+    redirects:
+      - prefix: /hidden
+    backend:
+      service:
+        name: test
+        ## port should be number
+        port: 1234
 
   ## For external traffic
   egress:


### PR DESCRIPTION
Added public vs private host delineation in variant-ui chart.

To test, navigate to the variant-ui chart in the repo and edit the values.yaml file to enable istio, add internal/public hosts, and internal paths

run 
`helm template  test-release . -n lazyapi-chart-test`
and
`helm upgrade --install  test-release . -n lazyapi-chart-test`
to validate the chart.