### PR TITLE
More thorough variant-api chart

### DIFF
--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for Istio Objects
 
-version: 1.1.0
+version: 2.0.0
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for Istio Objects
 
-version: 1.0.6
+version: 1.1.0
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for Istio Objects
 
-version: 2.0.0
+version: 2.0.0-beta1
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/HELM_CLI_USAGE.md
+++ b/charts/variant-api/HELM_CLI_USAGE.md
@@ -1,0 +1,10 @@
+# Helm CLI Usage
+
+To install the chart,
+first add the repo
+
+`helm repo add variant-inc-helm-charts https://variant-inc.github.io/lazy-helm-charts/ --password <token>`
+
+and then install the chart using
+
+`helm upgrade --install my-api variant-inc-helm-charts/variant-api -n my-namespace --set "istio.ingress.host=dev-drivevariant.com" --set "revision=abc123" --set "deployment.image.tag=ecr.amazonaws.com/my-project/my-api:abc123"`

--- a/charts/variant-api/MIGRATING.md
+++ b/charts/variant-api/MIGRATING.md
@@ -1,0 +1,171 @@
+# Migrating to variant-api 2.0
+
+## Definitions
+
+- **chart source** directory - Typically in `{project_root}/helm/{project_name}`. Source code of the helm chart that you are currently deploying.
+- **chart alias** - Typically `vsd`. In `{chart source}/Chart.yaml`, the value for the field `alias` under `dependencies` for `variant-api`.
+- **`helm_release`** resource - Typically in `{project_root}/terraform/{project_name}/release.tf` or `{project_root}/terraform/{project_name}/helm.tf`. Terraform resource used to deploy your helm chart where you provide `set` values.
+
+## Migration steps
+
+1. In `{chart source}/Chart.yaml`, in `dependencices:` Update `version` to `2.0.0` for the `variant-api` chart
+1. In `helm_release`, **remove** all `set` blocks with any of the following names:
+   - `fullnameOverride` -> the attribute `name` which should be set as `{your project}-api` will be used for all naming so this is now deprecated
+   - `replicaCount` -> See [Autoscaling](#autoscaling); autoscaling min/max replicas should be configured instead of deployment replicaCount
+   - `serviceAccount.name` -> See [Serivice Account](#service-account); see note on `fullnameOverride`
+   - `autoscaling.enabled` -> See [Autoscaling](#autoscaling); API autoscaling is not optional
+   - `global.service.name` -> see note on `fullnameOverride`
+1. In `helm_release`, **revise** all `set` blocks with any of the following names:
+   - `image.url` or `image.tag` -> `{chart alias}.deployment.image.tag`
+1. Set your required [Environment Variables](#environment-variables)
+1. Provide any [Startup Arguments](#startup-arguments)
+1. Set the correct [Ports](#ports)
+1. [Secrets](#secrets)
+1. Remove all of the following resources (`kind`) being created in `{chart source}/templates`
+   - HorizontalPodAutoscaler (typically in `hpa.yaml`)
+   - Deployment (typically in `deployment.yaml`)
+   - ServiceAccount (typically in `service-account.yaml`)
+   - Service (typically in `service.yaml`)
+1. Clear the contents of `{chart source}/values.yaml` (unless some values are used for custom resource deployments outside of this chart)
+
+### Service Account
+
+- The chart creates and names the service account for your API
+- Remove any terraform which creates the resource `kubernetes_service_account`
+- If your service account has an AWS role annotation, provide it by creating a `set` block where `name` is `{chart alias}.serviceAccount.roleArn`
+
+Example
+
+```bash
+  set {
+    name  = "{chart alias}.serviceAccount.roleArn"
+    value = aws_iam_role.role.arn
+  }
+```
+
+### Autoscaling
+
+Autoscaling is enabled by default. See the defaults in `autoscaling` section of [values.yaml](values.yaml) to override.
+
+Example
+
+```bash
+  set {
+    name  = "{chart alias}.autoscaling.minReplicas"
+    value = var.autoscaling_min_replicas
+  }
+
+  set {
+    name  = "{chart alias}.autoscaling.targetMemoryUtilizationPercentage"
+    value = var.autoscaling_memory_target
+  }
+```
+
+### Environment Variables
+
+1. In `{chart source}/templates/deployment.yaml` collect the environment variables **names** your API requires
+1. In `helm_release` determine which `set` blocks provide a `value` for the variables determined above
+   - `API_BASE_PATH` and `REVISION` are automatically provided by the 2.0 chart so the `set` blocks should be removed
+1. Use the example below to set your environment variables. Optionally, the rest of your `set` values can be provided in this values yaml format
+1. Remove any `set` blocks from step 2 above
+
+Example:
+
+```bash
+resource "helm_release" "test" {
+  repository = "https://variant-inc.github.io/lazy-helm-charts/"
+  chart      = "variant-api"
+  version    = "2.0.0"
+  name       = "schedule-adherence-api"
+  namespace  = kubernetes_namespace.test.metadata[0].name
+
+  values = [<<EOF
+{chart alias}:
+  deployment:
+    envVars:
+      - name: CONNECTIONSTRINGS__REDIS
+        value: "${var.redis_host}:${var.redis_port}"
+      - name: HERECLIENT__CACHE_DURATION_MINUTES
+        value: var.here_cache_duration_minutes
+      - name: EPSAGON_TOKEN
+        value: ${var.epsagon_token}
+      - name: EPSAGON_APP_NAME
+        value: ${var.epsagon_app_name}
+    conditionalEnvVars:
+      - condition: ${var.condition_one}
+        envVars:
+        - name: false_conditional
+          value: false_conditional
+      - condition: ${var.condition_two}
+        envVars:
+        - name: true_conditional_1
+          value: true_conditional_1
+        - name: true_conditional_2
+          value: true_conditional_2      
+EOF
+  ]
+
+  /* Pre-existing `set` blocks below
+    ...
+  */
+} 
+```
+
+### Startup Arguments
+
+Example:
+
+```bash
+resource "helm_release" "test" {
+  repository = "https://variant-inc.github.io/lazy-helm-charts/"
+  chart      = "variant-api"
+  version    = "2.0.0"
+  name       = "schedule-adherence-api"
+  namespace  = kubernetes_namespace.test.metadata[0].name
+
+  values = [<<EOF
+{chart alias}:
+  deployment:
+    args:
+      - Variant.ScheduleAdherence.Api.dll   
+EOF
+  ]
+
+  /* Pre-existing `set` blocks below
+    ...
+  */
+} 
+```
+
+### Ports
+
+Your API, health checks at `/health` and metrics at `/metrics` are expected to be at port 9000. Use the example below to override:
+
+Only {chart alias}.service.targetPort is required if all on the same port.
+
+Example:
+
+```bash
+resource "helm_release" "test" {
+  repository = "https://variant-inc.github.io/lazy-helm-charts/"
+  chart      = "variant-api"
+  version    = "2.0.0"
+  name       = "schedule-adherence-api"
+  namespace  = kubernetes_namespace.test.metadata[0].name
+
+  values = [<<EOF
+{chart alias}:
+  service:
+    targetPort: 5000
+    healthCheckPort: 5001
+    metricsPort: 5002  
+EOF
+  ]
+
+  /* Pre-existing `set` blocks below
+    ...
+  */
+} 
+```
+
+### Secrets

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,4 +1,24 @@
-# Variant Service Deployments Helm Chart
+# Variant API Helm Chart
+
+Use this chart to deploy an API image to Kubernetes -- the Variant, CloudOps-approved way.
+
+## Requirements
+
+### Must-do (your deployment will fail without these):
+
+1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
+1. Host a Prometheus metrics endpoint via `GET /metrics`
+   * This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   * Middleware exists for most major API frameworks that provide a useful out of the box HTTP server metrics, and simple tools to push custom metrics for your product:
+     * [.NET](https://github.com/prometheus-net/prometheus-net)
+     * Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
+     * Python - [Flask](https://github.com/rycus86/prometheus_flask_exporter), [Django](https://github.com/korfuri/django-prometheus)
+
+
+### Should-do (you have the option to override these in your deployment):
+
+1. Run on port 9000
+1. Run without any required arguments (i.e can be executed as `docker run [image]`)
 
 ## Install
 
@@ -31,12 +51,30 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - swagger
 - swaggerui
 
-## API Requirements
 
-Before deploying, your API should:
+## Minimum Required Inputs
 
-- Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
-- Host a Prometheus metrics endpoint via `GET /metrics`
+| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description |
+| - | - | - |
+| fullnameOverride | All | According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-api` such as `schedule-adherence-api` or `driver-api`. The root [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart.  |
+| revision | All | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
+| istio.ingress.host | VirtualService | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/LibraryVariableSets-121?activeTab=variables) Octopus Variable Set  |
+| deployment.image.tag | Deployment | The full URL of the image to be deployed containing the HTTP API application |
+
+
+## Optional Inputs
+
+| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
+| - | - | - | - | - |
+| istio.ingress.public | VirtualService | When `false`, an internal URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application *via OpenVPN-only*. When `true`, an additional public URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
+| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
+| istio.egress | ServiceEntry | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. | [ ] | [] |
+| istio.egress[N].name | ServiceEntry | A name for this whitelist entry | [x] | |
+| istio.egress[N].hosts | ServiceEntry | A list of hostnames to be whitelisted  | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
+| istio.egress[N].addresses | ServiceEntry | A list of IP addresses to be whitelisted | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
+| istio.egress[N].ports | ServiceEntry | A list of ports for the corresponding `istio.egress[N].hosts` or `istio.egress[N].addresses` to be whitelisted | [x] | [] |
+| istio.egress[N].ports[M].number | ServiceEntry | A port number | [x] | |
+| istio.egress[N].ports[M].protocol | ServiceEntry | Any of the protocols listed [here](https://istio.io/latest/docs/reference/config/networking/gateway/#Port) | [x] | |
 
 ## Object Reference
 
@@ -49,22 +87,3 @@ All possible objects created by this chart:
 - [Service](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
 - [ServiceAccount](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)
 - [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
-
-## Inputs
-
-Default values for all optional inputs can be seen in [values.yaml](values.yaml)
-
-| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
-| - | - | - | - | - |
-| fullnameOverride | All | The root [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart | [x] | |
-| revision | All | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) `revision` that will be applied to all objects created by a specific chart installation | [x] | |
-| istio.ingress.public | VirtualService | When `false`, an internal URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application via OpenVPN-only. When `true`, an additional public URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
-| istio.ingress.host | VirtualService | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/LibraryVariableSets-121?activeTab=variables) Octopus Variable Set  | [ ] | ops-drivevariant.com |
-| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
-| istio.egress | ServiceEntry | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. | [ ] | [] |
-| istio.egress[N].name | ServiceEntry | A name for this whitelist entry | [x] | |
-| istio.egress[N].hosts | ServiceEntry | A list of hostnames to be whitelisted  | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
-| istio.egress[N].addresses | ServiceEntry | A list of IP addresses to be whitelisted | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
-| istio.egress[N].ports | ServiceEntry | A list of ports for the corresponding `istio.egress[N].hosts` or `istio.egress[N].addresses` to be whitelisted | [x] | [] |
-| istio.egress[N].ports[M].number | ServiceEntry | A port number | [x] | |
-| istio.egress[N].ports[M].protocol | ServiceEntry | Any of the protocols listed [here](https://istio.io/latest/docs/reference/config/networking/gateway/#Port) | [x] | |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -30,3 +30,35 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - redoc
 - swagger
 - swaggerui
+
+## Object Reference
+
+All possible objects created by this chart:
+
+- [Deployment](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/)
+- [HorizontalPodAutoscaler](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1/)
+- [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)
+- [ServiceMonitor]()
+- [Service](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
+- [ServiceAccount](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)
+- [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
+
+## Inputs
+
+Default values for all optional inputs can be see in [values.yaml](values.yaml)
+
+| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
+| - | - | - | - | - |
+| fullnameOverride | All | The root [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart | [x] | |
+| revision | All | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) `revision` that will be applied to all objects created by a specific chart installation | [x] | |
+| istio.enabled | ServiceEntry, VirtualService | `false` if the API is fully internal (is only accessed by other apps within the same cluster AND does not require access to any services outside of the same cluster). This should almost always be `true` to be able to expose a QA endpoint for your API on VPN.  When `true`, a URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application. `internal` URLs require an OpenVPN connection. | [ ] | `false` |
+| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
+| istio.ingress.host | VirtualService | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/LibraryVariableSets-121?activeTab=variables) Octopus Variable Set  | [ ] | ops-drivevariant.com |
+| istio.ingress.public | VirtualService | When `true`, a URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
+| istio.egress | ServiceEntry | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. | [ ] | [] |
+| istio.egress[N].name | ServiceEntry | A name for this whitelist entry | [x] | |
+| istio.egress[N].hosts | ServiceEntry | A list of hostnames to be whitelisted  | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
+| istio.egress[N].addresses | ServiceEntry | A list of IP addresses to be whitelisted | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
+| istio.egress[N].ports | ServiceEntry | A list of ports for the corresponding `istio.egress[N].hosts` or `istio.egress[N].addresses` to be whitelisted | [x] | [] |
+| istio.egress[N].ports[M].number | ServiceEntry | A port number | [x] | |
+| istio.egress[N].ports[M].protocol | ServiceEntry | Any of the protocols listed [here](https://istio.io/latest/docs/reference/config/networking/gateway/#Port) | [x] | |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -31,6 +31,13 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - swagger
 - swaggerui
 
+## API Requirements
+
+Before deploying, your API should:
+
+- Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
+- Host a Prometheus metrics endpoint via `GET /metrics`
+
 ## Object Reference
 
 All possible objects created by this chart:
@@ -45,16 +52,15 @@ All possible objects created by this chart:
 
 ## Inputs
 
-Default values for all optional inputs can be see in [values.yaml](values.yaml)
+Default values for all optional inputs can be seen in [values.yaml](values.yaml)
 
 | Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
 | - | - | - | - | - |
 | fullnameOverride | All | The root [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart | [x] | |
 | revision | All | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) `revision` that will be applied to all objects created by a specific chart installation | [x] | |
-| istio.enabled | ServiceEntry, VirtualService | `false` if the API is fully internal (is only accessed by other apps within the same cluster AND does not require access to any services outside of the same cluster). This should almost always be `true` to be able to expose a QA endpoint for your API on VPN.  When `true`, a URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application. `internal` URLs require an OpenVPN connection. | [ ] | `false` |
-| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
+| istio.ingress.public | VirtualService | When `false`, an internal URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application via OpenVPN-only. When `true`, an additional public URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
 | istio.ingress.host | VirtualService | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/LibraryVariableSets-121?activeTab=variables) Octopus Variable Set  | [ ] | ops-drivevariant.com |
-| istio.ingress.public | VirtualService | When `true`, a URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
+| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
 | istio.egress | ServiceEntry | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. | [ ] | [] |
 | istio.egress[N].name | ServiceEntry | A name for this whitelist entry | [x] | |
 | istio.egress[N].hosts | ServiceEntry | A list of hostnames to be whitelisted  | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -4,7 +4,7 @@ Use this chart to deploy an API image to Kubernetes -- the Variant, CloudOps-app
 
 ## TL;DR
 
-TL;DR is based on the [Minimum Required Inputs](#minimum-required-inputs) and corresponding values in the example code block.
+Deploy your API using [Terraform](#terraform) or the [Helm CLI](#helm-cli) by providing the [Minimum Required Inputs](#minimum-required-inputs) 
 
 ### What can it do
 
@@ -56,6 +56,17 @@ resource "helm_release" "api_release" {
 }
 ```
 
+### Helm CLI
+
+To install the chart,
+first add the repo
+
+`helm repo add variant-inc-helm-charts https://variant-inc.github.io/lazy-helm-charts/ --password <token>`
+
+and then install the chart using
+
+`helm upgrade --install my-release-name variant-inc-helm-charts/variant-api -n my-namespace --set "istio.ingress.host=dev-drivevariant.com" --set "revision=abc123" --set "deployment.image.tag=ecr.amazonaws.com/my-project/my-api:abc123"`
+
 ## Before you start
 
 1. Use a CloudOps Github CI workflow that publishes an image
@@ -95,6 +106,14 @@ If only the minimum inputs are provided, these assumptions are made about your a
 | istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | `false` |
 | service.port | VirtualService, Service | | 80 |
 
+When using public ingess, the following URL prefixes are rerouted to the root URL and are essentially blocked. They must be accessed internally, or through VPN. You can add to this list in Values.istio.ingress.redirects.
+
+- health
+- docs
+- redoc
+- swagger
+- swaggerui
+
 ### Egress Configuration
 
 | Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
@@ -106,14 +125,6 @@ If only the minimum inputs are provided, these assumptions are made about your a
 | istio.egress[N].ports | ServiceEntry | A list of ports for the corresponding `istio.egress[N].hosts` or `istio.egress[N].addresses` to be whitelisted | [x] | [] |
 | istio.egress[N].ports[M].number | ServiceEntry | A port number | [x] | |
 | istio.egress[N].ports[M].protocol | ServiceEntry | Any of the protocols listed [here](https://istio.io/latest/docs/reference/config/networking/gateway/#Port) | [x] | |
-
-When using public ingess, the following URL prefixes are rerouted to the root URL and are essentially blocked. They must be accessed internally, or through VPN. You can add to this list in Values.istio.ingress.redirects.
-
-- health
-- docs
-- redoc
-- swagger
-- swaggerui
 
 ### Infrastructure Permissions
 
@@ -147,14 +158,3 @@ All possible objects created by this chart:
 - [Service](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
 - [ServiceAccount](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)
 - [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
-
-## Install
-
-To install the chart,
-first add the repo
-
-`helm repo add variant-inc-helm-charts https://variant-inc.github.io/lazy-helm-charts/ --password <token>`
-
-and then install the chart using
-
-`helm upgrade --install devops-services variant-inc-helm-charts/variant-api -n sample-ns -f values.yaml`

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -134,7 +134,10 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 
 | Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Default Value |
 | - | - | - | - |
-| service.targetPort | Service, Deployment | - | 9000 |
+| service.port | Service, ServiceMonitor | Port for internal services to access your API | 80 |
+| service.targetPort | Service, Deployment | Port on your container that exposes your HTTP API | 9000 |
+| service.metricsPort | Service, ServiceMonitor, Deployment | Port which serves prometheus metrics endpoint at `/metrics` | service.targetPort |
+| service.healthCheckPort | Service, ServiceMonitor, Deployment | - | service.targetPort |
 | deployment.args | Deployment | - | [] |
 | deployment.envVars | Deployment | - | [] |
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -2,10 +2,14 @@
 
 Use this chart to deploy an API image to Kubernetes -- the Variant, CloudOps-approved way.
 
-## Requirements
+## Before you start
 
-### Must-do (your deployment will fail without these):
+### Must-do (your deployment will be non-compliant, fail without these)
 
+1. Use a CloudOps Github CI workflow that publishes an image
+   * [.NET](https://github.com/variant-inc/actions-dotnet)
+   * [Node](https://github.com/variant-inc/actions-nodejs)
+   * [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics endpoint via `GET /metrics`
    * This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
@@ -15,10 +19,61 @@ Use this chart to deploy an API image to Kubernetes -- the Variant, CloudOps-app
      * Python - [Flask](https://github.com/rycus86/prometheus_flask_exporter), [Django](https://github.com/korfuri/django-prometheus)
 
 
-### Should-do (you have the option to override these in your deployment):
+### Should-do (you have the option to override these in your deployment)
 
 1. Run on port 9000
 1. Run without any required arguments (i.e can be executed as `docker run [image]`)
+
+
+## Minimum Required Inputs
+
+Providing the minimum required inputs results in a complete API deployment with these features:
+- Private - the API is reachable only via OpenVPN, or by other services inside the same cluster
+  - See [ingress confguration](#ingress-configuration) to make changes and information regarding the generated URLs
+- Firewall - the API can only reach [these services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) or other services inside the same cluster by default
+  - See [egress configuration](#egress-configuration) to whitelist additional services you need to reach outside of the cluster
+- No Infrastructure Access - Although Amazon services are firewall whitelisted, you still need to provide an AWS role that this API will be bound to for AWS permissions
+  - See [infrastructure permissions](#infrastructure-permissions)
+
+| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description |
+| - | - | - |
+| fullnameOverride | All | According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-api` such as `schedule-adherence-api` or `driver-api`. The root [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart.  |
+| revision | All | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
+| istio.ingress.host | VirtualService | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/LibraryVariableSets-121?activeTab=variables) Octopus Variable Set  |
+| deployment.image.tag | Deployment | The full URL of the image to be deployed containing the HTTP API application |
+
+
+## Optional Inputs
+
+### Ingress Configuration
+
+### Egress Configuration
+
+### Infrastructure Permissions
+
+| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
+| - | - | - | - | - |
+| istio.ingress.public | VirtualService | When `false`, an internal URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application *via OpenVPN-only*. When `true`, an additional public URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
+| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
+| istio.egress | ServiceEntry | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. | [ ] | [] |
+| istio.egress[N].name | ServiceEntry | A name for this whitelist entry | [x] | |
+| istio.egress[N].hosts | ServiceEntry | A list of hostnames to be whitelisted  | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
+| istio.egress[N].addresses | ServiceEntry | A list of IP addresses to be whitelisted | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
+| istio.egress[N].ports | ServiceEntry | A list of ports for the corresponding `istio.egress[N].hosts` or `istio.egress[N].addresses` to be whitelisted | [x] | [] |
+| istio.egress[N].ports[M].number | ServiceEntry | A port number | [x] | |
+| istio.egress[N].ports[M].protocol | ServiceEntry | Any of the protocols listed [here](https://istio.io/latest/docs/reference/config/networking/gateway/#Port) | [x] | |
+
+## Object Reference
+
+All possible objects created by this chart:
+
+- [Deployment](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/)
+- [HorizontalPodAutoscaler](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1/)
+- [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)
+- [ServiceMonitor]()
+- [Service](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
+- [ServiceAccount](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)
+- [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)
 
 ## Install
 
@@ -50,40 +105,3 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - redoc
 - swagger
 - swaggerui
-
-
-## Minimum Required Inputs
-
-| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description |
-| - | - | - |
-| fullnameOverride | All | According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-api` such as `schedule-adherence-api` or `driver-api`. The root [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart.  |
-| revision | All | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
-| istio.ingress.host | VirtualService | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/LibraryVariableSets-121?activeTab=variables) Octopus Variable Set  |
-| deployment.image.tag | Deployment | The full URL of the image to be deployed containing the HTTP API application |
-
-
-## Optional Inputs
-
-| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Required | Default Value |
-| - | - | - | - | - |
-| istio.ingress.public | VirtualService | When `false`, an internal URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application *via OpenVPN-only*. When `true`, an additional public URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`.  | [ ] | `false` |
-| istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | [ ] | `false` |
-| istio.egress | ServiceEntry | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. | [ ] | [] |
-| istio.egress[N].name | ServiceEntry | A name for this whitelist entry | [x] | |
-| istio.egress[N].hosts | ServiceEntry | A list of hostnames to be whitelisted  | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
-| istio.egress[N].addresses | ServiceEntry | A list of IP addresses to be whitelisted | One or both istio.egress[N].hosts and istio.egress[N].addresses must be specified | [] |
-| istio.egress[N].ports | ServiceEntry | A list of ports for the corresponding `istio.egress[N].hosts` or `istio.egress[N].addresses` to be whitelisted | [x] | [] |
-| istio.egress[N].ports[M].number | ServiceEntry | A port number | [x] | |
-| istio.egress[N].ports[M].protocol | ServiceEntry | Any of the protocols listed [here](https://istio.io/latest/docs/reference/config/networking/gateway/#Port) | [x] | |
-
-## Object Reference
-
-All possible objects created by this chart:
-
-- [Deployment](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/)
-- [HorizontalPodAutoscaler](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1/)
-- [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)
-- [ServiceMonitor]()
-- [Service](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
-- [ServiceAccount](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)
-- [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -145,6 +145,15 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 | deployment.resource | Deployment | - |
 | autoscaling | HorizontalPodAutoscaler | - |
 
+### Secrets
+
+| Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Default Value |
+| - | - | - | - |
+| secrets | ExternalSecret | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read. | [] |
+| secrets[N].name | ExternalSecret | Name of the AWS Secrets Manager secret |
+| secrets[N].fileName | ExternalSecret, Deployment | Desired file name which will contain all contents of the AWS secret |
+| secrets[N].mountPath | Deployment | Directory (no trailing slash) where the above secrets[N].fileName will be mounted (e.g. if fileName = secret.json and mountPath = /app/secrets then secret will be available at /app/secrets/secret.json) | |
+
 ## Kubernetes Object Reference
 
 All possible objects created by this chart:

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -7,7 +7,7 @@ Use this chart to deploy an API image to Kubernetes -- the Variant, CloudOps-app
 Review the [Assumptions](#assumptions) and provide the [Minimum Required Inputs](#minimum-required-input-table) to get deployed using Terraform:
 
 ```bash
-resource "kubernetes_namespace" "namespace" {
+resource "kubernetes_namespace" "test_namespace" {
   metadata {
     name = "my-namespace"
     labels = {
@@ -16,27 +16,28 @@ resource "kubernetes_namespace" "namespace" {
   }
 }
 
-resource "helm_release" "api_release" {
-  repository = "https://variant-inc.github.io/lazy-helm-charts/"
-  chart      = "variant-api"
-  version    = "2.0.0"
-  name       = "my-api"
-  namespace  = kubernetes_namespace.namespace.metadata[0].name
+resource "helm_release" "test_api_release" {
+  repository        = "https://variant-inc.github.io/lazy-helm-charts/"
+  chart             = "variant-api"
+  version           = "2.0.0"
+  name              = "test-my-api"
+  namespace         = kubernetes_namespace.test_namespace.metadata[0].name
+  lint              = true
+  dependency_update = true
 
-  set {
-    name  = "istio.ingress.host"
-    value = "dev-drivevariant.com"
-  }
+    values = [<<EOF
+revision: abc123
 
-  set {
-    name  = "deployment.image.tag"
-    value = "ecr.amazonaws.com/my-project/my-api:abc123"
-  }
+istio:
+  ingress:
+    host: dev-drivevariant.com
 
-  set {
-    name  = "revision"
-    value = "abc123
-  }
+deployment:
+  image:
+    tag: ecr.amazonaws.com/my-project/my-api:abc123
+
+EOF
+  ]
 }
 ```
 
@@ -140,6 +141,7 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 | service.healthCheckPort | Service, ServiceMonitor, Deployment | - | service.targetPort |
 | deployment.args | Deployment | - | [] |
 | deployment.envVars | Deployment | - | [] |
+| deployment.conditionalEnvVars | Deployment | - | [] |
 
 ### Resources and Scaling
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -4,7 +4,7 @@ Use this chart to deploy an API image to Kubernetes -- the Variant, CloudOps-app
 
 ## TL;DR
 
-Deploy your API using [Terraform](#terraform) or the [Helm CLI](#helm-cli) by providing the [Minimum Required Inputs](#minimum-required-inputs) 
+Deploy your API using [Terraform](#terraform) or the [Helm CLI](#helm-cli) by providing the [Minimum Required Inputs](#minimum-required-inputs)
 
 ### What can it do
 
@@ -19,7 +19,7 @@ Deploy your API using [Terraform](#terraform) or the [Helm CLI](#helm-cli) by pr
 
 ### Terraform
 
-```
+```bash
 resource "kubernetes_namespace" "namespace" {
   metadata {
     name = "my-namespace"
@@ -88,13 +88,16 @@ See [Application Configuration](#application-configuration) to override these as
 
 ### Release name
 
+According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-api` such as `schedule-adherence-api` or `driver-api`. 
+
 How to set release name
-- [Terraform](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#name)
+- Terraform
+  - `name` [argument](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#name) argument in the `helm_release` resource
 - Helm CLI
   - helm install [RELEASE_NAME] [CHART] [flags]
   - helm upgrade [RELEASE_NAME] [CHART] [flags]
 
-According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-api` such as `schedule-adherence-api` or `driver-api`. This will be used as the base [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart.
+This will be used as the base [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart.
 
 ### Minimum required input table
 
@@ -110,9 +113,14 @@ According to the [Workload Naming Conventions](https://drivevariant.atlassian.ne
 
 | Input | [Kubernetes Object Type](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) | Description | Default Value |
 | - | - | - | - |
-| istio.ingress.public | VirtualService | When `false`, an internal URL will be created with the format `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application *via OpenVPN-only*. When `true`, an additional public URL will be created with the format `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}` that will expose your application publicly. This API should be secured behind some authentication method when set to `true`. | `false` |
+| istio.ingress.public | VirtualService | When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*. When `true`, an additional publicly accesible URL will be created. This API should be secured behind some authentication method when set to `true`. | `false` |
 | istio.ingress.disableRewrite | VirtualService | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` | `false` |
 | service.port | VirtualService, Service | | 80 |
+
+URL Formats
+
+- Public: `api.{istio.ingress.host}/{target-namespace}/{helm-release-name}`
+- Private (OpenVPN): `api.internal.{istio.ingress.host}/{target-namespace}/{helm-release-name}`
 
 When using public ingess, the following URL prefixes are rerouted to the root URL and are essentially blocked. They must be accessed internally, or through VPN. You can add to this list in Values.istio.ingress.redirects.
 
@@ -162,7 +170,7 @@ All possible objects created by this chart:
 - [Deployment](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/)
 - [HorizontalPodAutoscaler](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v1/)
 - [ServiceEntry](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)
-- [ServiceMonitor]()
+- [ServiceMonitor](https://docs.openshift.com/container-platform/4.8/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html)
 - [Service](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
 - [ServiceAccount](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)
 - [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService)

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -4,7 +4,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "chart.fullname" -}}
-{{- required "fullnameOverride is required" .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -31,7 +31,7 @@ revision: {{ required "revision is required" .Values.revision | quote }}
 Selector labels
 */}}
 {{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.fullname" . }}
+app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -11,16 +11,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "chart.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- required "fullnameOverride is required" .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -49,4 +40,8 @@ Selector labels
 {{- define "chart.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "chart.ingressHostname" -}}
+{{- required "istio.ingress.host is required" .Values.istio.ingress.host }}
 {{- end }}

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "chart.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+revision: {{ required "revision is required" .Values.revision | quote }}
 {{- end }}
 
 {{/*

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -1,11 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "chart.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -38,7 +31,7 @@ revision: {{ required "revision is required" .Values.revision | quote }}
 Selector labels
 */}}
 {{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/name: {{ include "chart.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -79,3 +79,13 @@ spec:
               value: {{ required ".value is required for all envVars" .value }}
           {{- end }}
           {{- end }}
+          {{- if len .Values.deployment.conditionalEnvVars }}
+          {{- range .Values.deployment.conditionalEnvVars }}
+          {{- if .condition }}
+          {{- range .envVars }}
+            - name: {{ required ".name is required for all envVars" .name }}
+              value: {{ required ".value is required for all envVars" .value }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -65,16 +65,27 @@ spec:
             - name: http
               containerPort: {{ required "Target Port is required" .Values.service.targetPort }}
               protocol: TCP
+            {{- if .Values.service.metricsPort }}
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.service.healthCheckPort }}
+            - name: health
+              containerPort: {{ .Values.service.healthCheckPort }}
+              protocol: TCP
+            {{- end }}
+          {{ $port := ternary "http" "health" (empty .Values.service.healthCheckPort) }}
           livenessProbe:
             httpGet:
               path: /health
-              port: http
+              port: {{ $port }}
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /health
-              port: http
+              port: {{ $port }}
             initialDelaySeconds: 10
             periodSeconds: 10
           resources:

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -48,8 +48,10 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
-          {{- if len .Values.deployment.envVars }}
           env:
+            - name: REVISION
+              value: {{ required "revision is required" .Values.revision | quote }}
+          {{- if len .Values.deployment.envVars }}
           {{- range .Values.deployment.envVars }}
             - name: {{ required ".name is required for all envVars" .name }}
               value: {{ required ".value is required for all envVars" .value }}

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -22,6 +22,24 @@ spec:
     spec:
       serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true
+      ### Behold! Long explanation for why securityContext is set here:
+      #
+      # When the "eks.amazonaws.com/role-arn" annotation is applied to the ServiceAccount used by this Deployment, 
+      # some new volume is mounted which contains the AWS secrets for authentication. By default, the owner will 
+      # be root, but the AWS SDK in our applications need access to this volume at runtime and our applications 
+      # should _not_ run as root.
+      #
+      # fsGroup determines group ownership of volumes mounted in this dynamic manner.
+      #
+      # Assumptions:
+      # 1) The application process runs on an Alpine based platform -- the "nobody" group is defined as ID 65534 in Alpine
+      # 2) The application is running as a non-root user (u better be)
+      # 3) The non-root user _does not_ belong to any groups (i.e, "nobody")
+      #
+      # Let's not run as root
+      # Chown all the things that you own
+      # Groups of nobody
+      ###
       securityContext:
         fsGroup: 65534
       containers:

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         {{- $selectorLabels | nindent 8 }}
+      {{- with .Values.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -1,0 +1,57 @@
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- $selectorLabels | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- $selectorLabels | nindent 8 }}
+    spec:
+      serviceAccountName: {{ required "serviceAccount.name is required" .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 65534
+      containers:
+        - name: {{ $fullName }}
+          image: {{ required "image.tag is required" .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if len .Values.args }}
+          args: 
+          {{- range .Values.args }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ required "Target Port is required" .Values.service.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if len .Values.envVars }}
+          env:
+          {{- range .Values.envVars }}
+            - name: {{ required ".name is required for all envVars" .name }}
+              value: {{ required ".value is required for all envVars" .value }}
+          {{- end }}
+          {{- end }}

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -1,6 +1,7 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $secrets := .Values.secrets -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,15 +43,23 @@ spec:
       ###
       securityContext:
         fsGroup: 65534
+      {{- if len $secrets }}
+      volumes:
+        {{- range $secrets }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ $fullName}}-{{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ $fullName }}
           image: {{ required "deployment.image.tag is required" .Values.deployment.image.tag }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           {{- if len .Values.deployment.args }}
           args: 
-          {{- range .Values.deployment.args }}
+            {{- range .Values.deployment.args }}
             - {{ . }}
-          {{- end }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -73,19 +82,25 @@ spec:
           env:
             - name: REVISION
               value: {{ required "revision is required" .Values.revision | quote }}
-          {{- if len .Values.deployment.envVars }}
-          {{- range .Values.deployment.envVars }}
+            {{- range .Values.deployment.envVars }}
             - name: {{ required ".name is required for all envVars" .name }}
               value: {{ required ".value is required for all envVars" .value }}
-          {{- end }}
-          {{- end }}
-          {{- if len .Values.deployment.conditionalEnvVars }}
-          {{- range .Values.deployment.conditionalEnvVars }}
-          {{- if .condition }}
-          {{- range .envVars }}
+            {{- end }}
+            {{- if len .Values.deployment.conditionalEnvVars }}
+            {{- range .Values.deployment.conditionalEnvVars }}
+            {{- if .condition }}
+            {{- range .envVars }}
             - name: {{ required ".name is required for all envVars" .name }}
               value: {{ required ".value is required for all envVars" .value }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- if len $secrets }}
+          volumeMounts:
+            {{- range $secrets }}
+            - name: {{ .name }}
+              readOnly: true
+              mountPath: {{ .mountPath }}/{{ .fileName }}
+            {{- end }}
           {{- end }}

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -93,6 +93,8 @@ spec:
           env:
             - name: REVISION
               value: {{ required "revision is required" .Values.revision | quote }}
+            - name: API_BASE_PATH
+              value: /{{ .Release.Namespace }}/{{ .Release.Name }}
             {{- range .Values.deployment.envVars }}
             - name: {{ required ".name is required for all envVars" .name }}
               value: {{ required ".value is required for all envVars" .value }}
@@ -112,6 +114,6 @@ spec:
             {{- range $secrets }}
             - name: {{ .name }}
               readOnly: true
-              mountPath: {{ .mountPath }}/{{ .fileName }}
+              mountPath: {{ .mountPath }}
             {{- end }}
           {{- end }}

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -16,17 +16,17 @@ spec:
       labels:
         {{- $selectorLabels | nindent 8 }}
     spec:
-      serviceAccountName: {{ required "serviceAccount.name is required" .Values.serviceAccount.name }}
+      serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 65534
       containers:
         - name: {{ $fullName }}
-          image: {{ required "image.tag is required" .Values.image.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if len .Values.args }}
+          image: {{ required "deployment.image.tag is required" .Values.deployment.image.tag }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          {{- if len .Values.deployment.args }}
           args: 
-          {{- range .Values.args }}
+          {{- range .Values.deployment.args }}
             - {{ . }}
           {{- end }}
           {{- end }}
@@ -47,10 +47,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- if len .Values.envVars }}
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- if len .Values.deployment.envVars }}
           env:
-          {{- range .Values.envVars }}
+          {{- range .Values.deployment.envVars }}
             - name: {{ required ".name is required for all envVars" .name }}
               value: {{ required ".value is required for all envVars" .value }}
           {{- end }}

--- a/charts/variant-api/templates/external-secret.yaml
+++ b/charts/variant-api/templates/external-secret.yaml
@@ -1,0 +1,16 @@
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+{{- $secrets := .Values.secrets -}}
+{{- range $secrets }}
+apiVersion: 'kubernetes-client.io/v1'
+kind: ExternalSecret
+metadata:
+  name: {{ $fullName }}-{{ required "name is required for each secret" .name }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  backendType: secretsManager
+  data:
+    - key: {{ required "name is required for each secret" .name }}
+      name: {{ required "fileName is required for each secret" .fileName }}
+{{- end -}}

--- a/charts/variant-api/templates/hpa.yaml
+++ b/charts/variant-api/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $fullName }}
+  minReplicas: {{ required "autoscaling.minReplicas is required" .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ required "autoscaling.maxReplicas is required" .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if and (empty .Values.autoscaling.targetCPUUtilizationPercentage) (empty .Values.autoscaling.targetMemoryUtilizationPercentage) }}
+      {{- fail "autoscaling.targetCPUUtilizationPercentage or autoscaling.targetMemoryUtilizationPercentage must be specified" }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/variant-api/templates/hpa.yaml
+++ b/charts/variant-api/templates/hpa.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.autoscaling.enabled }}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 apiVersion: autoscaling/v2beta1
@@ -30,4 +29,3 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-{{- end }}

--- a/charts/variant-api/templates/service-entry.yaml
+++ b/charts/variant-api/templates/service-entry.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.istio.enabled -}}
 {{- $egress := .Values.istio.egress -}}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
@@ -30,5 +29,4 @@ spec:
       protocol: {{ .protocol | upper }}
     {{- end }}
   resolution: {{ .resolution | default "DNS" }}
-{{- end -}}
 {{- end -}}

--- a/charts/variant-api/templates/service-entry.yaml
+++ b/charts/variant-api/templates/service-entry.yaml
@@ -36,8 +36,8 @@ spec:
   ports:
     {{- range .ports }}
     - number: {{ .number }}
-      name: {{ .protocol | lower }}
-      protocol: {{ .protocol | upper }}
+      name: {{ .protocol | quote | lower }}
+      protocol: {{ .protocol | quote | upper }}
     {{- end }}
   resolution: {{ .resolution | default "DNS" }}
 {{- end -}}

--- a/charts/variant-api/templates/service-entry.yaml
+++ b/charts/variant-api/templates/service-entry.yaml
@@ -2,16 +2,25 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- range $egress }}
+{{- $name := printf "%s-%s" $fullName (required "A valid name is required for each ServiceEntry!" .name) }}
+{{ $hosts := .hosts }}
+{{- if and (not .hosts) .addresses }}
+  {{- /* 
+    If only addresses are provided, the name of this ServiceEntry 
+    can be used as the hostname to resolve the whitelisted addresses.
+  */}}
+  {{- $hosts = list $name }}
+{{- end }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
-  name: {{ $fullName }}-{{ required "A valid name is required for each ServiceEntry!" .name }}
+  name: {{ $name }}
   labels: {{ $labels | nindent 4 }}
 spec:
-  {{- if .hosts }}
+  {{- if $hosts }}
   hosts:
-    {{- range .hosts }}
+    {{- range $hosts }}
     - {{ . | quote }}
     {{- end }}
   {{- end }}

--- a/charts/variant-api/templates/service-entry.yaml
+++ b/charts/variant-api/templates/service-entry.yaml
@@ -9,10 +9,12 @@ metadata:
   name: {{ $fullName }}-{{ required "A valid name is required for each ServiceEntry!" .name }}
   labels: {{ $labels | nindent 4 }}
 spec:
+  {{- if .hosts }}
   hosts:
     {{- range .hosts }}
     - {{ . | quote }}
     {{- end }}
+  {{- end }}
   {{- if .addresses }}
   addresses:
     {{- range .addresses }}

--- a/charts/variant-api/templates/service-monitor.yaml
+++ b/charts/variant-api/templates/service-monitor.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceMonitor.enabled }}
 {{- $selectorLabels := (include "chart.selectorLabels" .) -}}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -19,4 +18,3 @@ spec:
   selector: 
     matchLabels:
       {{- $selectorLabels | nindent 6 }}
-{{- end }}

--- a/charts/variant-api/templates/service-monitor.yaml
+++ b/charts/variant-api/templates/service-monitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceMonitor.enabled }}
+{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -7,8 +8,8 @@ metadata:
   name: {{ include "chart.fullname" . }}
 spec:
   endpoints:
-    - targetPort: {{ default 9090 .Values.serviceMonitor.targetPort }}
-      port: {{ default "metrics" .Values.serviceMonitor.port }}
+    - targetPort: {{ default 9090 .Values.service.targetPort }}
+      port: {{ default "metrics" .Values.service.port }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
@@ -16,5 +17,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-  selector: {{- toYaml .Values.serviceMonitor.selector | nindent 4 }}
+  selector: 
+    matchLabels:
+      {{- $selectorLabels | nindent 6 }}
 {{- end }}

--- a/charts/variant-api/templates/service-monitor.yaml
+++ b/charts/variant-api/templates/service-monitor.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "chart.fullname" . }}
 spec:
   endpoints:
-    - port: {{ default "metrics" .Values.service.port }}
+    - targetPort: {{ ternary "http" "metrics" (empty .Values.service.metricsPort)}}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}

--- a/charts/variant-api/templates/service-monitor.yaml
+++ b/charts/variant-api/templates/service-monitor.yaml
@@ -8,8 +8,7 @@ metadata:
   name: {{ include "chart.fullname" . }}
 spec:
   endpoints:
-    - targetPort: {{ default 9090 .Values.service.targetPort }}
-      port: {{ default "metrics" .Values.service.port }}
+    - port: {{ default "metrics" .Values.service.port }}
       interval: {{ .Values.serviceMonitor.interval }}
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}

--- a/charts/variant-api/templates/service.yaml
+++ b/charts/variant-api/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- $selectorLabels | nindent 4 }}

--- a/charts/variant-api/templates/service.yaml
+++ b/charts/variant-api/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- $labels | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}

--- a/charts/variant-api/templates/service.yaml
+++ b/charts/variant-api/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: http
       protocol: TCP
       name: http
   selector:

--- a/charts/variant-api/templates/serviceaccount.yaml
+++ b/charts/variant-api/templates/serviceaccount.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $fullName }}
-  {{- if .Values.serviceAccount.roleArn }}
   labels:
     {{- $labels | nindent 4 }}
+  {{- if .Values.serviceAccount.roleArn }}
   annotations:
     "eks.amazonaws.com/role-arn": "{{ .Values.serviceAccount.roleArn }}" 
   {{- end }}

--- a/charts/variant-api/templates/serviceaccount.yaml
+++ b/charts/variant-api/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $labels := (include "chart.labels" .) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}
+  {{- if .Values.serviceAccount.roleArn }}
+  labels:
+    {{- $labels | nindent 4 }}
+  annotations:
+    "eks.amazonaws.com/role-arn": "{{ .Values.serviceAccount.roleArn }}" 
+  {{- end }}

--- a/charts/variant-api/templates/virtual-service-public.yaml
+++ b/charts/variant-api/templates/virtual-service-public.yaml
@@ -48,9 +48,9 @@ spec:
       {{ end -}}
       route:
         - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            host: {{ $fullName }}
             port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+              number: {{ .Values.service.port }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/variant-api/templates/virtual-service-public.yaml
+++ b/charts/variant-api/templates/virtual-service-public.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.istio.enabled -}}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- $release := .Release -}}
@@ -51,6 +50,5 @@ spec:
             host: {{ $fullName }}
             port:
               number: {{ .Values.service.port }}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/variant-api/templates/virtual-service-public.yaml
+++ b/charts/variant-api/templates/virtual-service-public.yaml
@@ -1,8 +1,8 @@
+{{- if .Values.istio.ingress.public }}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- $release := .Release -}}
-{{- if .Values.istio.ingress }}
-{{- if .Values.istio.ingress.public }}
+{{- $host := (include "chart.ingressHostname" .) -}}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -13,8 +13,8 @@ spec:
   gateways:
     - default/default
   hosts:
-    - api.{{ .Values.istio.ingress.host }}
-    - api.apps.{{ .Values.istio.ingress.host }}
+    - api.{{ $host }}
+    - api.apps.{{ $host }}
   http:
     - name: Private Path Redirects
       match:
@@ -35,7 +35,7 @@ spec:
         - uri:
             prefix: /{{ $release.Namespace }}/{{ $release.Name }}/swaggerui
       redirect:
-        authority: api.internal.apps.{{ .Values.istio.ingress.host }}
+        authority: api.internal.apps.{{ $host }}
         redirectCode: 307
     - name: Default Ingress
       match:
@@ -50,5 +50,4 @@ spec:
             host: {{ $fullName }}
             port:
               number: {{ .Values.service.port }}
-{{- end -}}
 {{- end -}}

--- a/charts/variant-api/templates/virtual-service.yaml
+++ b/charts/variant-api/templates/virtual-service.yaml
@@ -1,7 +1,7 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- $release := .Release -}}
-{{- if .Values.istio.ingress }}
+{{- $host := (include "chart.ingressHostname" .) -}}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -12,8 +12,8 @@ spec:
   gateways:
     - default/default
   hosts:
-    - api.internal.{{ .Values.istio.ingress.host }}
-    - api.internal.apps.{{ .Values.istio.ingress.host }}
+    - api.internal.{{ $host }}
+    - api.internal.apps.{{ $host }}
   http:
     - name: Private Ingress
       match:
@@ -28,4 +28,3 @@ spec:
             host: {{ $fullName }}
             port:
               number: {{ .Values.service.port }}
-{{- end -}}

--- a/charts/variant-api/templates/virtual-service.yaml
+++ b/charts/variant-api/templates/virtual-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.istio.enabled -}}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- $release := .Release -}}
@@ -29,5 +28,4 @@ spec:
             host: {{ $fullName }}
             port:
               number: {{ .Values.service.port }}
-{{- end -}}
 {{- end -}}

--- a/charts/variant-api/templates/virtual-service.yaml
+++ b/charts/variant-api/templates/virtual-service.yaml
@@ -26,8 +26,8 @@ spec:
       {{ end -}}
       route:
         - destination:
-            host: {{ tpl .Values.istio.ingress.backend.service.name $ }}
+            host: {{ $fullName }}
             port:
-              number: {{ int (tpl (.Values.istio.ingress.backend.service.port | toString) $) }}
+              number: {{ .Values.service.port }}
 {{- end -}}
 {{- end -}}

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 nameOverride: ""
-fullnameOverride: "schedule-adherence"
+fullnameOverride: ""
 
 istio:
-  enabled: true
+  enabled: false
   ## For traffic to the cluster
   ingress:
     # # Should the service be exposed via public ingress gateway?
@@ -45,7 +45,7 @@ istio:
     #       protocol: HTTPS
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   interval: 10s
   scrapeTimeout: 10s
 
@@ -62,34 +62,29 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
 
-image:
-  # SET via terrform syntax {alias}.image.tag
-  tag: abc123
-  pullPolicy: Always
-
-resources:
-  limits:
-    cpu: 1
-    memory: 768Mi
-  requests:
-    cpu: .1
-    memory: 384Mi
-
 # SET via terrform syntax {alias}.revision
-revision: abc123
+revision:
 
 serviceAccount:
-  # SET via terrform syntax {alias}.serviceAccount.name
-  name: service-account
   # SET via terrform syntax {alias}.serviceAccount.roleArn if AWS permissions are required
-  roleArn: amazon-role
+  roleArn:
 
-# SET via terraform syntax {alias}.args[0], {alias}.args[1], etc. for the number of args required
-args: [some, args]
+deployment:
+  image:
+    # SET via terrform syntax {alias}.image.tag
+    tag:
+    pullPolicy: Always
 
-# SET via terraform syntax in pairs of {alias}.envVars[0].name, {alias}.envVars[0].value
-envVars:
-  - name: env1
-    value: env1
-  - name: env2
-    value: env2
+  resources:
+    limits:
+      cpu: 1
+      memory: 768Mi
+    requests:
+      cpu: .1
+      memory: 384Mi
+
+  # SET via terraform syntax {alias}.args[0], {alias}.args[1], etc. for the number of args required
+  args: []
+
+  # SET via terraform syntax in pairs of {alias}.envVars[0].name, {alias}.envVars[0].value
+  envVars: []

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -1,4 +1,3 @@
-nameOverride: ""
 fullnameOverride:
 revision: 
 

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -1,11 +1,11 @@
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride:
 revision: 
 
 istio:
   ingress:
+    host:
     public: false
-    host: ops-drivevariant.com
     disableRewrite: false
 
     # Add endpoints to be rerouted to / in public access

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -1,48 +1,31 @@
-# Default values for istio.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 nameOverride: ""
 fullnameOverride: ""
+revision: 
 
 istio:
   enabled: false
-  ## For traffic to the cluster
   ingress:
-    # # Should the service be exposed via public ingress gateway?
-    public: true
-    # # Provide only the full hostname
+    public: false
     host: ops-drivevariant.com
-
-    # Make this as true if you want to handle the rewrite inside the app
     disableRewrite: false
 
     # Add endpoints to be rerouted to / in public access
     redirects:
       - prefix: /hidden
-    # # Should the endpoint be external or internal
-    backend:
-      service:
-        ## These values can be template variables
-        # name: {{ .Values.ReleaseName }}
-        # port: {{ .Global.service.port }}
-        name: test
-        ## port should be number
-        port: 1234
 
-  ## For external traffic
-  egress:
-    # ## List of hostnames and ports
-    # # Hosts should be FQDN
-    # - name:
+  egress: []
+    # - name: some-external-api
     #   hosts:
     #     - "test.example.com"
+    #   ports:
+    #     - number: 443
+    #       protocol: HTTPS
+    # - name: some-external-database
     #   addresses:
     #     - "10.0.0.1"
     #   ports:
-    #     - number: 123
-    #       ## MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|TCP|TLS
-    #       protocol: HTTPS
+    #     - number: 5432
+    #       protocol: TCP
 
 serviceMonitor:
   enabled: false
@@ -54,16 +37,12 @@ service:
   port: 80
   # Port # that exposes your HTTP application in your image
   targetPort: 9000
-  type: ClusterIP
 
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
-
-# SET via terrform syntax {alias}.revision
-revision:
 
 serviceAccount:
   # SET via terrform syntax {alias}.serviceAccount.roleArn if AWS permissions are required

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "schedule-adherence"
 
 istio:
-  enabled: false
+  enabled: true
   ## For traffic to the cluster
   ingress:
     # # Should the service be exposed via public ingress gateway?
@@ -45,9 +45,51 @@ istio:
     #       protocol: HTTPS
 
 serviceMonitor:
-  enabled: false
-  targetPort: 9090
+  enabled: true
   interval: 10s
   scrapeTimeout: 10s
-  # any label selector
-  selector: {}
+
+service:
+  # Port # exposed by the Kubernetes Service which will point to your deployed Pods
+  port: 80
+  # Port # that exposes your HTTP application in your image
+  targetPort: 9000
+  type: ClusterIP
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+image:
+  # SET via terrform syntax {alias}.image.tag
+  tag: abc123
+  pullPolicy: Always
+
+resources:
+  limits:
+    cpu: 1
+    memory: 768Mi
+  requests:
+    cpu: .1
+    memory: 384Mi
+
+# SET via terrform syntax {alias}.revision
+revision: abc123
+
+serviceAccount:
+  # SET via terrform syntax {alias}.serviceAccount.name
+  name: service-account
+  # SET via terrform syntax {alias}.serviceAccount.roleArn if AWS permissions are required
+  roleArn: amazon-role
+
+# SET via terraform syntax {alias}.args[0], {alias}.args[1], etc. for the number of args required
+args: [some, args]
+
+# SET via terraform syntax in pairs of {alias}.envVars[0].name, {alias}.envVars[0].value
+envVars:
+  - name: env1
+    value: env1
+  - name: env2
+    value: env2

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -27,6 +27,11 @@ serviceMonitor:
 service:
   port: 80
   targetPort: 9000
+  healthCheckPort:
+  metricsPort:
+
+serviceAccount:
+  roleArn:
 
 autoscaling:
   minReplicas: 1
@@ -35,7 +40,7 @@ autoscaling:
 
 deployment:
   image:
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   resources:
     limits:
       cpu: 1

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -37,6 +37,7 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage:
 
 deployment:
   image:

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -1,16 +1,11 @@
-fullnameOverride:
-revision: 
+# This file contains the defaults for all optional, overridable values
 
 istio:
   ingress:
-    host:
     public: false
     disableRewrite: false
-
-    # Add endpoints to be rerouted to / in public access
-    redirects:
-      - prefix: /hidden
-
+    redirects: []
+      # - prefix: /hidden
   egress: []
     # - name: some-external-api
     #   hosts:
@@ -30,9 +25,7 @@ serviceMonitor:
   scrapeTimeout: 10s
 
 service:
-  # Port # exposed by the Kubernetes Service which will point to your deployed Pods
   port: 80
-  # Port # that exposes your HTTP application in your image
   targetPort: 9000
 
 autoscaling:
@@ -40,16 +33,9 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
 
-serviceAccount:
-  # SET via terrform syntax {alias}.serviceAccount.roleArn if AWS permissions are required
-  roleArn:
-
 deployment:
   image:
-    # SET via terrform syntax {alias}.image.tag
-    tag:
     pullPolicy: Always
-
   resources:
     limits:
       cpu: 1
@@ -57,10 +43,19 @@ deployment:
     requests:
       cpu: .1
       memory: 384Mi
-
-  # SET via terraform syntax {alias}.args[0], {alias}.args[1], etc. for the number of args required
   args: []
-
-  # SET via terraform syntax in pairs of {alias}.envVars[0].name, {alias}.envVars[0].value
   envVars: []
+    # - name: required_env_var
+    #   value: required_env_var
+  conditionalEnvVars: []
+    # - condition: false
+    #   envVars:
+    #     - name: false_conditional
+    #       value: false_conditional
+    # - condition: true
+    #   envVars:
+    #     - name: true_conditional_1
+    #       value: true_conditional_1
+    #     - name: true_conditional_2
+    #       value: true_conditional_2
   podAnnotations: {}

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -3,7 +3,6 @@ fullnameOverride: ""
 revision: 
 
 istio:
-  enabled: false
   ingress:
     public: false
     host: ops-drivevariant.com
@@ -28,7 +27,6 @@ istio:
     #       protocol: TCP
 
 serviceMonitor:
-  enabled: false
   interval: 10s
   scrapeTimeout: 10s
 
@@ -39,7 +37,6 @@ service:
   targetPort: 9000
 
 autoscaling:
-  enabled: false
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -64,3 +64,4 @@ deployment:
 
   # SET via terraform syntax in pairs of {alias}.envVars[0].name, {alias}.envVars[0].value
   envVars: []
+  podAnnotations: {}

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -59,3 +59,8 @@ deployment:
     #     - name: true_conditional_2
     #       value: true_conditional_2
   podAnnotations: {}
+
+secrets: []
+  # - name: eng-secret-in-aws
+  #   mountPath: /app/secrets
+  #   fileName: aws-secret.json

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -203,6 +203,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
+  hosts:
+    - "schedule-adherence-api-database"
   addresses:
     - "1.1.1.1"
   exportTo:

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -82,6 +82,10 @@ spec:
       ###
       securityContext:
         fsGroup: 65534
+      volumes:
+        - name: eng-secret-in-aws
+          secret:
+            secretName: schedule-adherence-api-eng-secret-in-aws
       containers:
         - name: schedule-adherence-api
           image: ecr.amazonaws.com/schedule-adherence/schedule-adherence-api:abc123
@@ -118,6 +122,10 @@ spec:
               value: true_conditional_1
             - name: true_conditional_2
               value: true_conditional_2
+          volumeMounts:
+            - name: eng-secret-in-aws
+              readOnly: true
+              mountPath: /app/secrets/aws-secret.json
 ---
 # Source: variant-api/templates/hpa.yaml
 apiVersion: autoscaling/v2beta1
@@ -142,6 +150,23 @@ spec:
       resource:
         name: cpu
         targetAverageUtilization: 80
+---
+# Source: variant-api/templates/external-secret.yaml
+apiVersion: 'kubernetes-client.io/v1'
+kind: ExternalSecret
+metadata:
+  name: schedule-adherence-api-eng-secret-in-aws
+  labels:
+    helm.sh/chart: variant-api-2.0.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  backendType: secretsManager
+  data:
+    - key: eng-secret-in-aws
+      name: aws-secret.json
 ---
 # Source: variant-api/templates/service-entry.yaml
 apiVersion: networking.istio.io/v1beta1

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -4,6 +4,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: schedule-adherence-api
+  labels:
+    helm.sh/chart: variant-api-2.0.0
+    app.kubernetes.io/name: schedule-adherence-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+  annotations:
+    "eks.amazonaws.com/role-arn": "arn:aws:iam::account:role/role"
 ---
 # Source: variant-api/templates/service.yaml
 apiVersion: v1
@@ -12,7 +20,7 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
@@ -24,7 +32,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
 ---
 # Source: variant-api/templates/deployment.yaml
@@ -34,19 +42,19 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: variant-api
+      app.kubernetes.io/name: schedule-adherence-api
       app.kubernetes.io/instance: RELEASE-NAME
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: variant-api
+        app.kubernetes.io/name: schedule-adherence-api
         app.kubernetes.io/instance: RELEASE-NAME
       annotations:
         annotation1: annotation1
@@ -112,7 +120,7 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
@@ -136,7 +144,7 @@ metadata:
   name: schedule-adherence-api-here-api
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
@@ -159,7 +167,7 @@ metadata:
   name: schedule-adherence-api-database
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
@@ -181,7 +189,7 @@ kind: ServiceMonitor
 metadata:
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
@@ -196,7 +204,7 @@ spec:
       - schedule-adherence
   selector: 
     matchLabels:
-      app.kubernetes.io/name: variant-api
+      app.kubernetes.io/name: schedule-adherence-api
       app.kubernetes.io/instance: RELEASE-NAME
 ---
 # Source: variant-api/templates/virtual-service-public.yaml
@@ -206,7 +214,7 @@ metadata:
   name: schedule-adherence-api
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
@@ -251,7 +259,7 @@ metadata:
   name: schedule-adherence-api-internal
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/name: schedule-adherence-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -54,11 +54,29 @@ spec:
     spec:
       serviceAccountName: schedule-adherence-api
       automountServiceAccountToken: true
+      ### Behold! Long explanation for why securityContext is set here:
+      #
+      # When the "eks.amazonaws.com/role-arn" annotation is applied to the ServiceAccount used by this Deployment, 
+      # some new volume is mounted which contains the AWS secrets for authentication. By default, the owner will 
+      # be root, but the AWS SDK in our applications need access to this volume at runtime and our applications 
+      # should _not_ run as root.
+      #
+      # fsGroup determines group ownership of volumes mounted in this dynamic manner.
+      #
+      # Assumptions:
+      # 1) The application process runs on an Alpine based platform -- the "nobody" group is defined as ID 65534 in Alpine
+      # 2) The application is running as a non-root user (u better be)
+      # 3) The non-root user _does not_ belong to any groups (i.e, "nobody")
+      #
+      # Let's not run as root
+      # Chown all the things that you own
+      # Groups of nobody
+      ###
       securityContext:
         fsGroup: 65534
       containers:
         - name: schedule-adherence-api
-          image: abc123
+          image: ecr.amazonaws.com/schedule-adherence/schedule-adherence-api:abc123
           imagePullPolicy: Always
           ports:
             - name: http
@@ -115,7 +133,7 @@ spec:
 apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
-  name: schedule-adherence-api-test
+  name: schedule-adherence-api-here-api
   labels: 
     helm.sh/chart: variant-api-2.0.0
     app.kubernetes.io/name: variant-api
@@ -124,15 +142,37 @@ metadata:
     revision: "abc123"
 spec:
   hosts:
-    - "test.com"
-    - "blah.net"
+    - "api.hereapi.com"
   exportTo:
     - "."
   location: MESH_EXTERNAL
   ports:
-    - number: 80
-      name: http
-      protocol: HTTP
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: DNS
+---
+# Source: variant-api/templates/service-entry.yaml
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: schedule-adherence-api-database
+  labels: 
+    helm.sh/chart: variant-api-2.0.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  addresses:
+    - "1.1.1.1"
+  exportTo:
+    - "."
+  location: MESH_EXTERNAL
+  ports:
+    - number: 5432
+      name: tcp
+      protocol: TCP
   resolution: DNS
 ---
 # Source: variant-api/templates/service-monitor.yaml
@@ -159,6 +199,51 @@ spec:
       app.kubernetes.io/name: variant-api
       app.kubernetes.io/instance: RELEASE-NAME
 ---
+# Source: variant-api/templates/virtual-service-public.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: schedule-adherence-api
+  labels: 
+    helm.sh/chart: variant-api-2.0.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  gateways:
+    - default/default
+  hosts:
+    - api.dev-drivevariant.com
+    - api.apps.dev-drivevariant.com
+  http:
+    - name: Private Path Redirects
+      match:
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/hidden
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/health
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/docs
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/redoc
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/swagger
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/swaggerui
+      redirect:
+        authority: api.internal.apps.dev-drivevariant.com
+        redirectCode: 307
+    - name: Default Ingress
+      match:
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/
+      route:
+        - destination:
+            host: schedule-adherence-api
+            port:
+              number: 80
+---
 # Source: variant-api/templates/virtual-service.yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -174,15 +259,13 @@ spec:
   gateways:
     - default/default
   hosts:
-    - api.internal.ops-drivevariant.com
-    - api.internal.apps.ops-drivevariant.com
+    - api.internal.dev-drivevariant.com
+    - api.internal.apps.dev-drivevariant.com
   http:
     - name: Private Ingress
       match:
         - uri:
             prefix: /schedule-adherence/RELEASE-NAME/
-      rewrite:
-        uri: /
       route:
         - destination:
             host: schedule-adherence-api

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -3,21 +3,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: schedule-adherence
-  labels:
-    helm.sh/chart: variant-api-1.1.0
-    app.kubernetes.io/name: variant-api
-    app.kubernetes.io/instance: RELEASE-NAME
-    app.kubernetes.io/managed-by: Helm
-    revision: "abc123"
-  annotations:
-    "eks.amazonaws.com/role-arn": "amazon-role"
+  name: schedule-adherence-api
 ---
 # Source: variant-api/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: schedule-adherence
+  name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-1.1.0
     app.kubernetes.io/name: variant-api
@@ -39,7 +31,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: schedule-adherence
+  name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-1.1.0
     app.kubernetes.io/name: variant-api
@@ -57,17 +49,14 @@ spec:
         app.kubernetes.io/name: variant-api
         app.kubernetes.io/instance: RELEASE-NAME
     spec:
-      serviceAccountName: service-account
+      serviceAccountName: schedule-adherence-api
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 65534
       containers:
-        - name: schedule-adherence
+        - name: schedule-adherence-api
           image: abc123
           imagePullPolicy: Always
-          args:
-            - some
-            - args
           ports:
             - name: http
               containerPort: 9000
@@ -91,11 +80,30 @@ spec:
             requests:
               cpu: 0.1
               memory: 384Mi
-          env:
-            - name: env1
-              value: env1
-            - name: env2
-              value: env2
+---
+# Source: variant-api/templates/hpa.yaml
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: schedule-adherence-api
+  labels:
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: schedule-adherence-api
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
 ---
 # Source: variant-api/templates/service-monitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -107,7 +115,7 @@ metadata:
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
-  name: schedule-adherence
+  name: schedule-adherence-api
 spec:
   endpoints:
     - targetPort: 9000
@@ -126,7 +134,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: schedule-adherence
+  name: schedule-adherence-api
   labels: 
     helm.sh/chart: variant-api-1.1.0
     app.kubernetes.io/name: variant-api
@@ -165,7 +173,7 @@ spec:
         uri: /
       route:
         - destination:
-            host: schedule-adherence
+            host: schedule-adherence-api
             port:
               number: 80
 ---
@@ -173,7 +181,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: schedule-adherence-internal
+  name: schedule-adherence-api-internal
   labels: 
     helm.sh/chart: variant-api-1.1.0
     app.kubernetes.io/name: variant-api
@@ -195,6 +203,6 @@ spec:
         uri: /
       route:
         - destination:
-            host: schedule-adherence
+            host: schedule-adherence-api
             port:
               number: 80

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -6,8 +6,8 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
   annotations:
@@ -20,8 +20,8 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
@@ -32,8 +32,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
 ---
 # Source: variant-api/templates/deployment.yaml
 apiVersion: apps/v1
@@ -42,20 +42,20 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: schedule-adherence-api
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/name: variant-api
+      app.kubernetes.io/instance: schedule-adherence-api
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: schedule-adherence-api
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: variant-api
+        app.kubernetes.io/instance: schedule-adherence-api
       annotations:
         annotation1: annotation1
         annotation2: annotation2
@@ -120,8 +120,8 @@ metadata:
   name: schedule-adherence-api
   labels:
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
@@ -144,8 +144,8 @@ metadata:
   name: schedule-adherence-api-here-api
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
@@ -167,8 +167,8 @@ metadata:
   name: schedule-adherence-api-database
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
@@ -189,8 +189,8 @@ kind: ServiceMonitor
 metadata:
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
   name: schedule-adherence-api
@@ -204,8 +204,8 @@ spec:
       - schedule-adherence
   selector: 
     matchLabels:
-      app.kubernetes.io/name: schedule-adherence-api
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/name: variant-api
+      app.kubernetes.io/instance: schedule-adherence-api
 ---
 # Source: variant-api/templates/virtual-service-public.yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -214,8 +214,8 @@ metadata:
   name: schedule-adherence-api
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
@@ -228,24 +228,24 @@ spec:
     - name: Private Path Redirects
       match:
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/hidden
+            prefix: /schedule-adherence/schedule-adherence-api/hidden
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/health
+            prefix: /schedule-adherence/schedule-adherence-api/health
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/docs
+            prefix: /schedule-adherence/schedule-adherence-api/docs
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/redoc
+            prefix: /schedule-adherence/schedule-adherence-api/redoc
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/swagger
+            prefix: /schedule-adherence/schedule-adherence-api/swagger
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/swaggerui
+            prefix: /schedule-adherence/schedule-adherence-api/swaggerui
       redirect:
         authority: api.internal.apps.dev-drivevariant.com
         redirectCode: 307
     - name: Default Ingress
       match:
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/
+            prefix: /schedule-adherence/schedule-adherence-api/
       route:
         - destination:
             host: schedule-adherence-api
@@ -259,8 +259,8 @@ metadata:
   name: schedule-adherence-api-internal
   labels: 
     helm.sh/chart: variant-api-2.0.0
-    app.kubernetes.io/name: schedule-adherence-api
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: schedule-adherence-api
     app.kubernetes.io/managed-by: Helm
     revision: "abc123"
 spec:
@@ -273,7 +273,7 @@ spec:
     - name: Private Ingress
       match:
         - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/
+            prefix: /schedule-adherence/schedule-adherence-api/
       route:
         - destination:
             host: schedule-adherence-api

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -1,0 +1,200 @@
+---
+# Source: variant-api/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: schedule-adherence
+  labels:
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+  annotations:
+    "eks.amazonaws.com/role-arn": "amazon-role"
+---
+# Source: variant-api/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: schedule-adherence
+  labels:
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9000
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+---
+# Source: variant-api/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: schedule-adherence
+  labels:
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: variant-api
+      app.kubernetes.io/instance: RELEASE-NAME
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: variant-api
+        app.kubernetes.io/instance: RELEASE-NAME
+    spec:
+      serviceAccountName: service-account
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 65534
+      containers:
+        - name: schedule-adherence
+          image: abc123
+          imagePullPolicy: Always
+          args:
+            - some
+            - args
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1
+              memory: 768Mi
+            requests:
+              cpu: 0.1
+              memory: 384Mi
+          env:
+            - name: env1
+              value: env1
+            - name: env2
+              value: env2
+---
+# Source: variant-api/templates/service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels: 
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+  name: schedule-adherence
+spec:
+  endpoints:
+    - targetPort: 9000
+      port: 80
+      interval: 10s
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - schedule-adherence
+  selector: 
+    matchLabels:
+      app.kubernetes.io/name: variant-api
+      app.kubernetes.io/instance: RELEASE-NAME
+---
+# Source: variant-api/templates/virtual-service-public.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: schedule-adherence
+  labels: 
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  gateways:
+    - default/default
+  hosts:
+    - api.ops-drivevariant.com
+    - api.apps.ops-drivevariant.com
+  http:
+    - name: Private Path Redirects
+      match:
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/hidden
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/health
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/docs
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/redoc
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/swagger
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/swaggerui
+      redirect:
+        authority: api.internal.apps.ops-drivevariant.com
+        redirectCode: 307
+    - name: Default Ingress
+      match:
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: schedule-adherence
+            port:
+              number: 80
+---
+# Source: variant-api/templates/virtual-service.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: schedule-adherence-internal
+  labels: 
+    helm.sh/chart: variant-api-1.1.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  gateways:
+    - default/default
+  hosts:
+    - api.internal.ops-drivevariant.com
+    - api.internal.apps.ops-drivevariant.com
+  http:
+    - name: Private Ingress
+      match:
+        - uri:
+            prefix: /schedule-adherence/RELEASE-NAME/
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: schedule-adherence
+            port:
+              number: 80

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -112,6 +112,12 @@ spec:
           env:
             - name: REVISION
               value: "abc123"
+            - name: required_env_var
+              value: required_env_var
+            - name: true_conditional_1
+              value: true_conditional_1
+            - name: true_conditional_2
+              value: true_conditional_2
 ---
 # Source: variant-api/templates/hpa.yaml
 apiVersion: autoscaling/v2beta1
@@ -227,8 +233,6 @@ spec:
   http:
     - name: Private Path Redirects
       match:
-        - uri:
-            prefix: /schedule-adherence/schedule-adherence-api/hidden
         - uri:
             prefix: /schedule-adherence/schedule-adherence-api/health
         - uri:

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -48,6 +48,9 @@ spec:
       labels:
         app.kubernetes.io/name: variant-api
         app.kubernetes.io/instance: RELEASE-NAME
+      annotations:
+        annotation1: annotation1
+        annotation2: annotation2
     spec:
       serviceAccountName: schedule-adherence-api
       automountServiceAccountToken: true

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -28,7 +28,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 9000
+      targetPort: http
       protocol: TCP
       name: http
   selector:
@@ -94,16 +94,23 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
+            - name: metrics
+              containerPort: 9999
+              protocol: TCP
+            - name: health
+              containerPort: 8888
+              protocol: TCP
+          
           livenessProbe:
             httpGet:
               path: /health
-              port: http
+              port: health
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /health
-              port: http
+              port: health
             initialDelaySeconds: 10
             periodSeconds: 10
           resources:
@@ -229,7 +236,7 @@ metadata:
   name: schedule-adherence-api
 spec:
   endpoints:
-    - port: 80
+    - targetPort: metrics
       interval: 10s
       scrapeTimeout: 10s
   namespaceSelector:

--- a/temp/out.yaml
+++ b/temp/out.yaml
@@ -11,7 +11,7 @@ kind: Service
 metadata:
   name: schedule-adherence-api
   labels:
-    helm.sh/chart: variant-api-1.1.0
+    helm.sh/chart: variant-api-2.0.0
     app.kubernetes.io/name: variant-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
@@ -33,7 +33,7 @@ kind: Deployment
 metadata:
   name: schedule-adherence-api
   labels:
-    helm.sh/chart: variant-api-1.1.0
+    helm.sh/chart: variant-api-2.0.0
     app.kubernetes.io/name: variant-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
@@ -80,6 +80,9 @@ spec:
             requests:
               cpu: 0.1
               memory: 384Mi
+          env:
+            - name: REVISION
+              value: "abc123"
 ---
 # Source: variant-api/templates/hpa.yaml
 apiVersion: autoscaling/v2beta1
@@ -87,7 +90,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: schedule-adherence-api
   labels:
-    helm.sh/chart: variant-api-1.1.0
+    helm.sh/chart: variant-api-2.0.0
     app.kubernetes.io/name: variant-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
@@ -105,12 +108,36 @@ spec:
         name: cpu
         targetAverageUtilization: 80
 ---
+# Source: variant-api/templates/service-entry.yaml
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: schedule-adherence-api-test
+  labels: 
+    helm.sh/chart: variant-api-2.0.0
+    app.kubernetes.io/name: variant-api
+    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/managed-by: Helm
+    revision: "abc123"
+spec:
+  hosts:
+    - "test.com"
+    - "blah.net"
+  exportTo:
+    - "."
+  location: MESH_EXTERNAL
+  ports:
+    - number: 80
+      name: http
+      protocol: HTTP
+  resolution: DNS
+---
 # Source: variant-api/templates/service-monitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels: 
-    helm.sh/chart: variant-api-1.1.0
+    helm.sh/chart: variant-api-2.0.0
     app.kubernetes.io/name: variant-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm
@@ -118,8 +145,7 @@ metadata:
   name: schedule-adherence-api
 spec:
   endpoints:
-    - targetPort: 9000
-      port: 80
+    - port: 80
       interval: 10s
       scrapeTimeout: 10s
   namespaceSelector:
@@ -130,60 +156,13 @@ spec:
       app.kubernetes.io/name: variant-api
       app.kubernetes.io/instance: RELEASE-NAME
 ---
-# Source: variant-api/templates/virtual-service-public.yaml
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: schedule-adherence-api
-  labels: 
-    helm.sh/chart: variant-api-1.1.0
-    app.kubernetes.io/name: variant-api
-    app.kubernetes.io/instance: RELEASE-NAME
-    app.kubernetes.io/managed-by: Helm
-    revision: "abc123"
-spec:
-  gateways:
-    - default/default
-  hosts:
-    - api.ops-drivevariant.com
-    - api.apps.ops-drivevariant.com
-  http:
-    - name: Private Path Redirects
-      match:
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/hidden
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/health
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/docs
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/redoc
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/swagger
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/swaggerui
-      redirect:
-        authority: api.internal.apps.ops-drivevariant.com
-        redirectCode: 307
-    - name: Default Ingress
-      match:
-        - uri:
-            prefix: /schedule-adherence/RELEASE-NAME/
-      rewrite:
-        uri: /
-      route:
-        - destination:
-            host: schedule-adherence-api
-            port:
-              number: 80
----
 # Source: variant-api/templates/virtual-service.yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: schedule-adherence-api-internal
   labels: 
-    helm.sh/chart: variant-api-1.1.0
+    helm.sh/chart: variant-api-2.0.0
     app.kubernetes.io/name: variant-api
     app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/managed-by: Helm

--- a/temp/test-values.yaml
+++ b/temp/test-values.yaml
@@ -1,0 +1,28 @@
+fullnameOverride: schedule-adherence-api
+revision: abc123
+
+deployment:
+  image:
+    tag: ecr.amazonaws.com/schedule-adherence/schedule-adherence-api:abc123
+  podAnnotations:
+    annotation1: annotation1
+    annotation2: annotation2
+
+istio:
+  ingress:
+    public: true
+    host: dev-drivevariant.com
+    disableRewrite: true
+  egress:
+    - name: here-api
+      hosts: 
+        - api.hereapi.com
+      ports:
+        - number: 443
+          protocol: HTTPS
+    - name: database
+      addresses:
+        - 1.1.1.1
+      ports:
+        - number: 5432
+          protocol: TCP

--- a/temp/test-values.yaml
+++ b/temp/test-values.yaml
@@ -42,3 +42,8 @@ istio:
       ports:
         - number: 5432
           protocol: TCP
+
+secrets:
+  - name: eng-secret-in-aws
+    mountPath: /app/secrets
+    fileName: aws-secret.json

--- a/temp/test-values.yaml
+++ b/temp/test-values.yaml
@@ -47,3 +47,7 @@ secrets:
   - name: eng-secret-in-aws
     mountPath: /app/secrets
     fileName: aws-secret.json
+
+service:
+  healthCheckPort: 8888
+  metricsPort: 9999

--- a/temp/test-values.yaml
+++ b/temp/test-values.yaml
@@ -1,4 +1,3 @@
-fullnameOverride: schedule-adherence-api
 revision: abc123
 
 deployment:
@@ -7,6 +6,20 @@ deployment:
   podAnnotations:
     annotation1: annotation1
     annotation2: annotation2
+  envVars:
+    - name: required_env_var
+      value: required_env_var
+  conditionalEnvVars:
+    - condition: false
+      envVars:
+        - name: false_conditional
+          value: false_conditional
+    - condition: true
+      envVars:
+        - name: true_conditional_1
+          value: true_conditional_1
+        - name: true_conditional_2
+          value: true_conditional_2
 
 serviceAccount:
   roleArn: arn:aws:iam::account:role/role

--- a/temp/test-values.yaml
+++ b/temp/test-values.yaml
@@ -8,6 +8,9 @@ deployment:
     annotation1: annotation1
     annotation2: annotation2
 
+serviceAccount:
+  roleArn: arn:aws:iam::account:role/role
+
 istio:
   ingress:
     public: true


### PR DESCRIPTION
Initial draft. I will open a PR with the proper template if we decide to move forward with this.

My end-goal with these changes is to remove the need for resource templates from individual repositories. App developers only need to populate their `values.yaml`. For any runtime values, provide the values using the current pattern via terraform/octopus variables + the terraform `helm_release` resource.