### PR TITLE
Handle Istio in variant-cron

### DIFF
--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.0.1
+version: 1.1.0
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -2,7 +2,7 @@
 
 Use this chart to deploy a CronJob image to Kubernetes -- the Variant, CloudOps-approved way.
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 
@@ -14,8 +14,6 @@ A Helm chart for Istio Objects
 | affinity | object | `{}` |  |
 | awsSecrets | list | `[]` |  |
 | configVars | object | `{}` |  |
-| cronJob.args | list | `[]` |  |
-| cronJob.command | list | `[]` |  |
 | cronJob.image.pullPolicy | string | `"Always"` |  |
 | cronJob.image.tag | string | `nil` |  |
 | cronJob.podAnnotations | object | `{}` |  |
@@ -24,6 +22,7 @@ A Helm chart for Istio Objects
 | cronJob.resources.requests.cpu | float | `0.1` |  |
 | cronJob.resources.requests.memory | string | `"384Mi"` |  |
 | cronJob.schedule | string | `nil` |  |
+| cronJob.script | string | `nil` | full path to the job script to execute |
 | cronJob.suspend | bool | `false` |  |
 | imagePullSecrets | list | `[]` |  |
 | istio.egress | list | `[]` |  |
@@ -39,6 +38,7 @@ A Helm chart for Istio Objects
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `false` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `nil` | Optional. Used for integration testing. If provided, will override the `USER` command in your Dockerfile |
 | serviceAccount.roleArn | string | `nil` |  |
 | tags | string | `nil` |  |
 | tolerations | list | `[]` |  |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -14,6 +14,7 @@ A Helm chart for Istio Objects
 | affinity | object | `{}` |  |
 | awsSecrets | list | `[]` |  |
 | configVars | object | `{}` |  |
+| cronJob.command | list | `nil` | full path to the job script to execute |
 | cronJob.image.pullPolicy | string | `"Always"` |  |
 | cronJob.image.tag | string | `nil` |  |
 | cronJob.podAnnotations | object | `{}` |  |
@@ -22,7 +23,6 @@ A Helm chart for Istio Objects
 | cronJob.resources.requests.cpu | float | `0.1` |  |
 | cronJob.resources.requests.memory | string | `"384Mi"` |  |
 | cronJob.schedule | string | `nil` |  |
-| cronJob.script | string | `nil` | full path to the job script to execute |
 | cronJob.suspend | bool | `false` |  |
 | imagePullSecrets | list | `[]` |  |
 | istio.egress | list | `[]` |  |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -24,6 +24,7 @@ A Helm chart for Istio Objects
 | cronJob.resources.requests.cpu | float | `0.1` |  |
 | cronJob.resources.requests.memory | string | `"384Mi"` |  |
 | cronJob.schedule | string | `nil` |  |
+| cronJob.suspend | bool | `false` |  |
 | imagePullSecrets | list | `[]` |  |
 | istio.egress | list | `[]` |  |
 | node.create | bool | `false` |  |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -28,8 +28,8 @@ A Helm chart for Istio Objects
 | istio.egress | list | `[]` |  |
 | node.create | bool | `false` |  |
 | node.instanceType | string | `"r5.xlarge"` |  |
-| node.ttlSecondsAfterEmpty | int | `1800` |  |
-| node.ttlSecondsUntilExpired | int | `2592000` |  |
+| node.ttlSecondsAfterEmpty | int | `3600` |  |
+| node.ttlSecondsUntilExpired | string | `nil` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `65534` |  |
 | revision | string | `nil` |  |

--- a/charts/variant-cron/ci/default-values.yaml
+++ b/charts/variant-cron/ci/default-values.yaml
@@ -32,7 +32,9 @@ cronJob:
       memory: 384Mi
   args: []
   podAnnotations: {}
-  script: /bin/echo "Hello from the K8s cluster"
+  command: 
+    - /bin/echo 
+    - Hello from the K8s cluster
   suspend: true
 
 secrets: []

--- a/charts/variant-cron/ci/default-values.yaml
+++ b/charts/variant-cron/ci/default-values.yaml
@@ -22,7 +22,7 @@ cronJob:
   schedule: "*/2 * * * *"
   image:
     pullPolicy: IfNotPresent
-    tag: busybox:latest
+    tag: curlimages/curl
   resources:
     limits:
       cpu: 1
@@ -32,10 +32,8 @@ cronJob:
       memory: 384Mi
   args: []
   podAnnotations: {}
-  command:
-    - "/bin/sh"
-    - "-c"
-    - "date; echo Hello from the K8s cluster"
+  script: /bin/echo "Hello from the K8s cluster"
+  suspend: true
 
 secrets: []
   #- name: eng-secret-in-aws
@@ -67,3 +65,6 @@ CLUSTER_NAME: devops-playground
 
 tags:
   owner: platform-infrastructure
+
+securityContext:
+  runAsUser: 1001

--- a/charts/variant-cron/ci/default-values.yaml
+++ b/charts/variant-cron/ci/default-values.yaml
@@ -48,20 +48,10 @@ configVars:
 
 revision: "test-latest"
 
-nodeSelector:
-  purpose: prime-test
-  env: dpl
-
-tolerations:
-  - key: "lee-test"
-
 affinity: {}
 
 node:
   create: false
-  instanceType: t3.medium
-  ttlSecondsUntilExpired: 2592000
-  ttlSecondsAfterEmpty: 1800
 
 CLUSTER_NAME: devops-playground
 

--- a/charts/variant-cron/ci/provisioner-values.yaml
+++ b/charts/variant-cron/ci/provisioner-values.yaml
@@ -1,0 +1,22 @@
+cronJob:
+  schedule: "*/2 * * * *"
+  image:
+    tag: curlimages/curl
+  command: 
+    - /bin/echo 
+    - Hello from the K8s cluster
+  suspend: true
+
+revision: "test-provisioner"
+
+node:
+  create: true
+  instanceType: t3.medium
+
+CLUSTER_NAME: devops-playground
+
+tags:
+  test: lazy-helm-provisioner-test
+
+securityContext:
+  runAsUser: 1001

--- a/charts/variant-cron/ci/unit/defaults.yaml
+++ b/charts/variant-cron/ci/unit/defaults.yaml
@@ -22,6 +22,7 @@ tests:
   - it: should have provisioner
     release:
       name: test
+      namespace: test
     set:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
@@ -44,7 +45,7 @@ tests:
         containsDocument:
           apiVersion: karpenter.sh/v1alpha5
           kind: Provisioner
-          name: test
+          name: test-test
       - template: provisioner.yaml
         hasDocuments:
           count: 1

--- a/charts/variant-cron/ci/unit/defaults.yaml
+++ b/charts/variant-cron/ci/unit/defaults.yaml
@@ -7,7 +7,9 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.script: /bin/sh -c date; echo Hello from unit test"
+      cronJob.command: 
+        - /bin/echo
+        - "Hello from unit test"
     asserts:
       - template: cron.yaml
         containsDocument:
@@ -24,7 +26,9 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.script: /bin/sh -c date; echo Hello from unit test"
+      cronJob.command: 
+        - /bin/echo
+        - "Hello from unit test"
       node:
         create: true
         instanceType: t3.medium

--- a/charts/variant-cron/ci/unit/defaults.yaml
+++ b/charts/variant-cron/ci/unit/defaults.yaml
@@ -7,10 +7,7 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.command:
-        - "/bin/sh"
-        - "-c"
-        - "date; echo Hello from unit test"
+      cronJob.script: /bin/sh -c date; echo Hello from unit test"
     asserts:
       - template: cron.yaml
         containsDocument:
@@ -19,7 +16,7 @@ tests:
           name: test
       - template: cron.yaml
         hasDocuments:
-          count: 1
+          count: 2
   - it: should have provisioner
     release:
       name: test
@@ -27,10 +24,7 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.command:
-        - "/bin/sh"
-        - "-c"
-        - "date; echo Hello from unit test"
+      cronJob.script: /bin/sh -c date; echo Hello from unit test"
       node:
         create: true
         instanceType: t3.medium

--- a/charts/variant-cron/ci/unit/suspend.yaml
+++ b/charts/variant-cron/ci/unit/suspend.yaml
@@ -7,12 +7,10 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.command:
-        - "/bin/sh"
-        - "-c"
-        - "date; echo Hello from unit test"
+      cronJob.script: /bin/sh -c date; echo Hello from unit test"
     asserts:
       - template: cron.yaml
+        documentIndex: 0
         equal:
           # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
           path: spec.suspend
@@ -24,13 +22,11 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.command:
-        - "/bin/sh"
-        - "-c"
-        - "date; echo Hello from unit test"
+      cronJob.script: /bin/sh -c date; echo Hello from unit test"
       cronJob.suspend: true
     asserts:
       - template: cron.yaml
+        documentIndex: 0
         equal:
           # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
           path: spec.suspend

--- a/charts/variant-cron/ci/unit/suspend.yaml
+++ b/charts/variant-cron/ci/unit/suspend.yaml
@@ -1,0 +1,37 @@
+suite: Suspension
+tests:
+  - it: by default should not be suspended
+    release:
+      name: test
+    set:
+      cronJob.image.tag: busybox:latest
+      cronJob.schedule: "*/2 * * * *"
+      revision: revision
+      cronJob.command:
+        - "/bin/sh"
+        - "-c"
+        - "date; echo Hello from unit test"
+    asserts:
+      - template: cron.yaml
+        equal:
+          # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
+          path: spec.suspend
+          value: false
+  - it: allows cronjob to be suspended
+    release:
+      name: test
+    set:
+      cronJob.image.tag: busybox:latest
+      cronJob.schedule: "*/2 * * * *"
+      revision: revision
+      cronJob.command:
+        - "/bin/sh"
+        - "-c"
+        - "date; echo Hello from unit test"
+      cronJob.suspend: true
+    asserts:
+      - template: cron.yaml
+        equal:
+          # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
+          path: spec.suspend
+          value: true

--- a/charts/variant-cron/ci/unit/suspend.yaml
+++ b/charts/variant-cron/ci/unit/suspend.yaml
@@ -7,7 +7,9 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.script: /bin/sh -c date; echo Hello from unit test"
+      cronJob.command: 
+        - /bin/echo
+        - "Hello from unit test"
     asserts:
       - template: cron.yaml
         documentIndex: 0
@@ -22,7 +24,9 @@ tests:
       cronJob.image.tag: busybox:latest
       cronJob.schedule: "*/2 * * * *"
       revision: revision
-      cronJob.script: /bin/sh -c date; echo Hello from unit test"
+      cronJob.command: 
+        - /bin/echo
+        - "Hello from unit test"
       cronJob.suspend: true
     asserts:
       - template: cron.yaml

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -68,20 +68,26 @@ template:
     restartPolicy: OnFailure
     serviceAccountName: {{ $fullName }}
     automountServiceAccountToken: true
-    {{- if len .Values.nodeSelector }}
     nodeSelector:
+    {{- if .Values.node.create }}
+      node.kubernetes.io/instance-type: {{ .Values.node.instanceType | quote }}
+    {{- end }}
       {{- range $key, $value := .Values.nodeSelector }}
       {{ $key }}: {{ $value }}
       {{- end }}
-    {{- end }}
     {{- if len .Values.affinity }}
     affinity:
       {{- range $key, $value := .Values.affinity }}
       {{ $key }}: {{ toYaml $value }}
       {{- end }}
     {{- end }}
-    {{- if len .Values.tolerations }}
     tolerations:
+    {{- if .Values.node.create }}
+      - key: "namespace"
+        value: {{ .Release.Namespace | quote }}
+        operator: "Equal"
+        effect: "NoSchedule"
+    {{- end }}
       {{- range .Values.tolerations }}
       - key: {{ required "Key is required for tolerations" .key | quote }}
         operator: {{ .operator | default "Exists" | quote }}
@@ -90,7 +96,6 @@ template:
         {{- end }}
         effect: {{ .effect | default "NoSchedule" | quote }}
       {{- end }}
-    {{- end }}
 parallelism: 1
 backoffLimit: 2
 {{- end}}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -39,7 +39,7 @@ template:
           - |
             until curl -fsI http://localhost:15021/healthz/ready; do echo \"Waiting for Sidecar...\"; sleep 3; done;
             echo \"Sidecar available. Running the command...\";
-            {{ required "Absolute path to job script must be provided" .Values.cronJob.script }};
+            {{ required "Command list must be provided" (join " " .Values.cronJob.command) }};
             x=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $x
         resources:
           {{- toYaml (required "Resources is required" .Values.cronJob.resources) | nindent 10 }}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -33,16 +33,14 @@ template:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         imagePullPolicy: {{ .Values.cronJob.image.pullPolicy }}
-        {{- if len .Values.cronJob.args }}
-        args: 
-          {{- range .Values.cronJob.args }}
-          - {{ . }}
-          {{- end }}
-        {{- end }}
-        {{- if len .Values.cronJob.command }}
         command:
-          {{- toYaml (required "cronJob.command is required" .Values.cronJob.command) | nindent 10 }}
-        {{- end }}
+          - /bin/sh
+          - -c
+          - |
+            until curl -fsI http://localhost:15021/healthz/ready; do echo \"Waiting for Sidecar...\"; sleep 3; done;
+            echo \"Sidecar available. Running the command...\";
+            {{ required "Absolute path to job script must be provided" .Values.cronJob.script }};
+            x=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $x
         resources:
           {{- toYaml (required "Resources is required" .Values.cronJob.resources) | nindent 10 }}
         {{ if or (len $secretEnv) (len $configEnv) -}}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -1,0 +1,98 @@
+{{- define "chart.jobspec" }}
+{{- $fullName := (include "chart.fullname" .) -}}
+{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $secrets := .Values.awsSecrets -}}
+{{- $secretEnv := .Values.secretVars -}}
+{{- $configEnv := .Values.configVars -}}
+template:
+  metadata:
+    labels:
+      {{- $selectorLabels | nindent 6 }}
+    {{- with .Values.cronJob.podAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  spec:
+    {{- with .Values.imagePullSecrets }}
+    imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 6 }}
+    {{- if len $secrets }}
+    volumes:
+      {{- range $secrets }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ $fullName}}-{{ .name }}
+      {{- end }}
+    {{- end }}
+    containers:
+      - name: {{ $fullName }}
+        image: {{ required "cronJob.image.tag is required" .Values.cronJob.image.tag }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        imagePullPolicy: {{ .Values.cronJob.image.pullPolicy }}
+        {{- if len .Values.cronJob.args }}
+        args: 
+          {{- range .Values.cronJob.args }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
+        {{- if len .Values.cronJob.command }}
+        command:
+          {{- toYaml (required "cronJob.command is required" .Values.cronJob.command) | nindent 10 }}
+        {{- end }}
+        resources:
+          {{- toYaml (required "Resources is required" .Values.cronJob.resources) | nindent 10 }}
+        {{ if or (len $secretEnv) (len $configEnv) -}}
+        envFrom:
+          {{ if len $secretEnv -}}
+          - secretRef:
+              name: {{ include "chart.fullname" . }}-env
+          {{- end }}
+          {{ if len $configEnv -}}
+          - configMapRef:
+              name: {{ include "chart.fullname" . }}-config-env
+          {{- end }}
+        {{- end }}
+        {{ if len $secrets}}
+        volumeMounts:
+          {{- range $secrets }}
+          - name: {{ .name }}
+            readOnly: true
+            mountPath: /app/secrets
+          {{- end }}
+        {{- end}}
+        env:
+          - name: REVISION
+            value: {{ required "revision is required" .Values.revision | quote }}
+    restartPolicy: OnFailure
+    serviceAccountName: {{ $fullName }}
+    automountServiceAccountToken: true
+    {{- if len .Values.nodeSelector }}
+    nodeSelector:
+      {{- range $key, $value := .Values.nodeSelector }}
+      {{ $key }}: {{ $value }}
+      {{- end }}
+    {{- end }}
+    {{- if len .Values.affinity }}
+    affinity:
+      {{- range $key, $value := .Values.affinity }}
+      {{ $key }}: {{ toYaml $value }}
+      {{- end }}
+    {{- end }}
+    {{- if len .Values.tolerations }}
+    tolerations:
+      {{- range .Values.tolerations }}
+      - key: {{ required "Key is required for tolerations" .key | quote }}
+        operator: {{ .operator | default "Exists" | quote }}
+        {{- if hasKey . "value"  }}
+        value: {{ .value | quote }}
+        {{- end }}
+        effect: {{ .effect | default "NoSchedule" | quote }}
+      {{- end }}
+    {{- end }}
+parallelism: 1
+backoffLimit: 2
+{{- end}}

--- a/charts/variant-cron/templates/cron.yaml
+++ b/charts/variant-cron/templates/cron.yaml
@@ -11,7 +11,7 @@ spec:
   schedule: {{  required "cronJob.schedule is required" .Values.cronJob.schedule | quote }}
   concurrencyPolicy: {{  .Values.cronJob.concurrencyPolicy  }}
   startingDeadlineSeconds: {{ .Values.cronJob.startingDeadlineSeconds  }}
-  suspend: false
+  suspend: {{ .Values.cronJob.suspend }}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/charts/variant-cron/templates/cron.yaml
+++ b/charts/variant-cron/templates/cron.yaml
@@ -1,9 +1,6 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "chart.labels" .) -}}
 {{- $selectorLabels := (include "chart.selectorLabels" .) -}}
-{{- $secrets := .Values.awsSecrets -}}
-{{- $secretEnv := .Values.secretVars -}}
-{{- $configEnv := .Values.configVars -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -18,95 +15,4 @@ spec:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   jobTemplate:
-    spec:
-      template:
-        metadata:
-          labels:
-            {{- $selectorLabels | nindent 12 }}
-          {{- with .Values.cronJob.podAnnotations }}
-          annotations:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-        spec:
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          securityContext:
-            {{- toYaml .Values.podSecurityContext | nindent 12 }}
-          {{- if len $secrets }}
-          volumes:
-            {{- range $secrets }}
-            - name: {{ .name }}
-              secret:
-                secretName: {{ $fullName}}-{{ .name }}
-            {{- end }}
-          {{- end }}
-          containers:
-            - name: {{ $fullName }}
-              image: {{ required "cronJob.image.tag is required" .Values.cronJob.image.tag }}
-              securityContext:
-                {{- toYaml .Values.securityContext | nindent 16 }}
-              imagePullPolicy: {{ .Values.cronJob.image.pullPolicy }}
-              {{- if len .Values.cronJob.args }}
-              args: 
-                {{- range .Values.cronJob.args }}
-                - {{ . }}
-                {{- end }}
-              {{- end }}
-              {{- if len .Values.cronJob.command }}
-              command:
-                {{- toYaml (required "cronJob.command is required" .Values.cronJob.command) | nindent 14 }}
-              {{- end }}
-              resources:
-                {{- toYaml (required "Resources is required" .Values.cronJob.resources) | nindent 16 }}
-              {{ if or (len $secretEnv) (len $configEnv) -}}
-              envFrom:
-                {{ if len $secretEnv -}}
-                - secretRef:
-                    name: {{ include "chart.fullname" . }}-env
-                {{- end }}
-                {{ if len $configEnv -}}
-                - configMapRef:
-                    name: {{ include "chart.fullname" . }}-config-env
-                {{- end }}
-              {{- end }}
-              {{ if len $secrets}}
-              volumeMounts:
-                {{- range $secrets }}
-                - name: {{ .name }}
-                  readOnly: true
-                  mountPath: /app/secrets
-                {{- end }}
-              {{- end}}
-              env:
-                - name: REVISION
-                  value: {{ required "revision is required" .Values.revision | quote }}
-          restartPolicy: OnFailure
-          serviceAccountName: {{ $fullName }}
-          automountServiceAccountToken: true
-          {{- if len .Values.nodeSelector }}
-          nodeSelector:
-            {{- range $key, $value := .Values.nodeSelector }}
-            {{ $key }}: {{ $value }}
-            {{- end }}
-          {{- end }}
-          {{- if len .Values.affinity }}
-          affinity:
-            {{- range $key, $value := .Values.affinity }}
-            {{ $key }}: {{ toYaml $value | nindent 14 }}
-            {{- end }}
-          {{- end }}
-          {{- if len .Values.tolerations }}
-          tolerations:
-            {{- range .Values.tolerations }}
-            - key: {{ required "Key is required for tolerations" .key | quote }}
-              operator: {{ .operator | default "Exists" | quote }}
-              {{- if hasKey . "value"  }}
-              value: {{ .value | quote }}
-              {{- end }}
-              effect: {{ .effect | default "NoSchedule" | quote }}
-            {{- end }}
-          {{- end }}
-      parallelism: 1
-      backoffLimit: 2
+    spec: {{ include "chart.jobspec" . | nindent 6 }}

--- a/charts/variant-cron/templates/cron.yaml
+++ b/charts/variant-cron/templates/cron.yaml
@@ -16,3 +16,14 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec: {{ include "chart.jobspec" . | nindent 6 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    {{- $labels | nindent 4 }}
+spec: {{ include "chart.jobspec" . | nindent 2 }}

--- a/charts/variant-cron/templates/provisioner.yaml
+++ b/charts/variant-cron/templates/provisioner.yaml
@@ -3,7 +3,7 @@
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
-  name: {{ $fullName }}
+  name: {{ .Release.Namespace }}-{{ $fullName }}
 spec:
   # If nil, the feature is disabled, nodes will never expire
   # 30 Days Default = 60 * 60 * 24 * 30 Seconds;
@@ -15,6 +15,9 @@ spec:
   # Provisioned nodes will have these taints
   # Taints may prevent pods from scheduling if they are not tolerated
   taints:
+    - key: "namespace"
+      value: {{ .Release.Namespace | quote }}
+      effect: "NoSchedule"
     {{- range .Values.tolerations }}
     - key: {{ required "Key is required for tolerations" .key | quote }}
       effect: {{ .effect | default "NoSchedule" | quote }}

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -82,8 +82,8 @@ affinity: {}
 node:
   create: false
   instanceType: r5.xlarge
-  ttlSecondsUntilExpired: 2592000
-  ttlSecondsAfterEmpty: 1800
+  ttlSecondsUntilExpired:
+  ttlSecondsAfterEmpty: 3600
 
 CLUSTER_NAME: variant-dev
 

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -25,6 +25,8 @@ podSecurityContext:
 
 securityContext:
   runAsNonRoot: true
+  # -- (int) Optional. Used for integration testing. If provided, will override the `USER` command in your Dockerfile
+  runAsUser:
   capabilities:
     drop:
     - ALL
@@ -44,12 +46,9 @@ cronJob:
     requests:
       cpu: .1
       memory: 384Mi
-  args: []
   podAnnotations: {}
-  command: []
-    # - "/bin/sh"
-    # - "-c"
-    # - "date; echo Hello from the K8s cluster"
+  # -- (string) full path to the job script to execute
+  script:
   suspend: false
 
 awsSecrets: []

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -47,8 +47,8 @@ cronJob:
       cpu: .1
       memory: 384Mi
   podAnnotations: {}
-  # -- (string) full path to the job script to execute
-  script:
+  # -- (list) full path to the job script to execute
+  command:
   suspend: false
 
 awsSecrets: []

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -50,6 +50,7 @@ cronJob:
     # - "/bin/sh"
     # - "-c"
     # - "date; echo Hello from the K8s cluster"
+  suspend: false
 
 awsSecrets: []
   # - name: eng-secret-in-aws


### PR DESCRIPTION
# Description

- Integration test actually runs a job -- created a helper method for JobSpec so that it can be reused to actually do integration test of the job
- Exposed option to `suspend` jobs in case of emergency, and so that our integration tests can be deployed as `suspend: true`
- _runAsUser_ : bring back `runAsUser` for testing purposes. Before we had it as `1000` which would ignore `USER` in images. Now it is `nil` which will respect usage of `USER` in images. Now, we can override it in chart integration tests and still use images like `busybox` and `curlimages/curl` without Kubernetes getting mad about root
- ~~_cronJob.script_ : remove `cronJob.command` and `cronJob.args` and instead require a `cronJob.script` input from the user. The user should `COPY` their job script to their image and then provide the full path to the script here. We are doing this so we can wait for Istio startup and then shutdown Istio gracefully without developer knowledge~~
- users will require `curl` in their image
- revised unit tests
- removed `cronJob.args` - users must provide a `cronJob.command` list

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Unit + integration test that deploys job 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
