### PR TITLE
variant-handler hotfix - probes and env vars

### DIFF
--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.0.1
+version: 1.0.2
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 
@@ -24,8 +24,10 @@ A Helm chart for kubernetes handler
 | deployment.resources.limits.memory | string | `"768Mi"` |  |
 | deployment.resources.requests.cpu | float | `0.1` |  |
 | deployment.resources.requests.memory | string | `"384Mi"` |  |
+| livenessProbe | string | `nil` | See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `65534` |  |
+| readinessProbe | string | `nil` | See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs |
 | replicaCount | int | `1` |  |
 | revision | string | `"abc"` | (string) Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision`  that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
 | secretVars | list | `[]` |  |

--- a/charts/variant-handler/ci/default-values.yaml
+++ b/charts/variant-handler/ci/default-values.yaml
@@ -11,3 +11,9 @@ podSecurityContext:
   fsGroup: 65534
 
 securityContext: {}
+
+livenessProbe:
+  exec:
+    command:
+      - /bin/echo
+      - "hello world"

--- a/charts/variant-handler/templates/deployment.yaml
+++ b/charts/variant-handler/templates/deployment.yaml
@@ -82,40 +82,13 @@ spec:
               containerPort: {{ .Values.service.healthCheckPort }}
               protocol: TCP
             {{- end }}
-          {{ $port := ternary "http" "health" (empty .Values.service.healthCheckPort) }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.service.healthCheckPath }}
-              port: {{ $port }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.service.healthCheckPath }}
-              port: {{ $port }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
+          livenessProbe: {{ .Values.livenessProbe | toYaml | nindent 12 }}
+          readinessProbe: {{ .Values.readinessProbe | toYaml | nindent 12 }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           env:
             - name: REVISION
               value: {{ required "revision is required" .Values.revision | quote }}
-            {{- $secretName := (printf "%s-%s" (include "chart.fullname" .) "secret") -}}
-            {{- range $key, $value := .Values.secretVars }}
-            - name: {{ $key | quote }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: {{ $key }}
-            {{- end }}
-            {{- $configMapName := (printf "%s-%s" (include "chart.fullname" .) "config") -}}
-            {{- range $key, $value := .Values.configsVars }}
-            - name: {{ $key | quote }}
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $configMapName }}
-                  key: {{ $key }}
-            {{- end }}
           {{- if len $secrets }}
           volumeMounts:
             {{- range $secrets }}

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -92,3 +92,9 @@ tolerations: []
 # Affinity for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+# -- See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs
+readinessProbe:
+
+# -- See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs
+livenessProbe:


### PR DESCRIPTION
# Description

* Probes for variant-handler should be optional
* Drop usage of `configMapKeyRef` and `secretKeyRef` because we are already using `envFrom` on the container

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Modified variant-handler integration test to use optional `livenessProbe`
* Deployed xpress-technologies-broker https://github.com/variant-inc/xpress-technologies-broker/pull/1

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
