### PR TITLE
default Pod restart policy on job to Never

### DIFF
--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.1.0
+version: 1.1.1
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -2,7 +2,7 @@
 
 Use this chart to deploy a CronJob image to Kubernetes -- the Variant, CloudOps-approved way.
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 
@@ -32,6 +32,7 @@ A Helm chart for Istio Objects
 | node.ttlSecondsUntilExpired | string | `nil` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `65534` |  |
+| restartPolicy | string | `"Never"` | Use Never by default for jobs so new pod is created on failure instead of restarting containers |
 | revision | string | `nil` |  |
 | secretVars | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |

--- a/charts/variant-cron/ci/unit/defaults.yaml
+++ b/charts/variant-cron/ci/unit/defaults.yaml
@@ -49,3 +49,19 @@ tests:
       - template: provisioner.yaml
         hasDocuments:
           count: 1
+  - it: defaults to Never restart policy
+    release:
+      name: test
+    set:
+      cronJob.image.tag: busybox:latest
+      cronJob.schedule: "*/2 * * * *"
+      revision: revision
+      cronJob.command: 
+        - /bin/echo
+        - "Hello from unit test"
+    asserts:
+      - template: cron.yaml
+        documentIndex: 0
+        equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: Never

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -65,7 +65,7 @@ template:
         env:
           - name: REVISION
             value: {{ required "revision is required" .Values.revision | quote }}
-    restartPolicy: OnFailure
+    restartPolicy: {{ .Values.restartPolicy }}
     serviceAccountName: {{ $fullName }}
     automountServiceAccountToken: true
     nodeSelector:

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -89,3 +89,6 @@ CLUSTER_NAME: variant-dev
 
 ## Tags to be applied to custom node provisioner
 tags:
+
+# -- Use Never by default for jobs so new pod is created on failure instead of restarting containers
+restartPolicy: Never


### PR DESCRIPTION
# Description

It's hard to debug failed jobs when `restartPolicy: OnFailure` because Kubernetes will restart the failed _container_ instead of creating a new _pod_ , so we lose log output/pod state via Lens or other tools.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] unit/integration tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
