### PR TITLE
Feature/configmap hash

### DIFF
--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.0
+version: 2.1.1
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -38,3 +38,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "chart.ingressHostname" -}}
 {{- required "istio.ingress.host is required" .Values.istio.ingress.host }}
 {{- end }}
+
+{{- define "chart.podAnnotations" -}}
+{{- if len .Values.configVars }}
+checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}
+{{- if len .Values.awsSecrets }}
+checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- end }}
+checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
+{{- range .Values.configMaps }}
+checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+{{- end }}
+{{- with .Values.deployment.podAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -16,8 +16,18 @@ spec:
     metadata:
       labels:
         {{- $selectorLabels | nindent 8 }}
-      {{- with .Values.deployment.podAnnotations }}
       annotations:
+      {{ if len .Values.configVars }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{ if len $secrets }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- end }}
+        checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
+      {{- range .Values.configMaps }}
+        checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+      {{- end }}
+      {{- with .Values.deployment.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -17,19 +17,7 @@ spec:
       labels:
         {{- $selectorLabels | nindent 8 }}
       annotations:
-      {{ if len .Values.configVars }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-      {{- end }}
-      {{ if len $secrets }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-      {{- end }}
-        checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
-      {{- range .Values.configMaps }}
-        checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
-      {{- end }}
-      {{- with .Values.deployment.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "chart.podAnnotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.0
+version: 1.2.1
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -2,7 +2,7 @@
 
 Use this chart to deploy a CronJob image to Kubernetes -- the Variant, CloudOps-approved way.
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/templates/_helpers.tpl
+++ b/charts/variant-cron/templates/_helpers.tpl
@@ -38,3 +38,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "chart.ingressHostname" -}}
 {{- required "istio.ingress.host is required" .Values.istio.ingress.host }}
 {{- end }}
+
+{{- define "chart.podAnnotations" -}}
+{{- if len .Values.configVars }}
+checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}
+{{- if len .Values.awsSecrets }}
+checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- end }}
+checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
+{{- range .Values.configMaps }}
+checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+{{- end }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -6,10 +6,8 @@ template:
   metadata:
     labels:
       {{- $selectorLabels | nindent 6 }}
-    {{- with .Values.cronJob.podAnnotations }}
     annotations:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+      {{- include "chart.podAnnotations" . | indent 6 }}
   spec:
     {{- with .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.0
+version: 1.1.1
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/templates/_helpers.tpl
+++ b/charts/variant-handler/templates/_helpers.tpl
@@ -34,3 +34,19 @@ Selector labels
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{- define "chart.podAnnotations" -}}
+{{- if len .Values.configVars }}
+checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}
+{{- if len .Values.awsSecrets }}
+checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- end }}
+checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
+{{- range .Values.configMaps }}
+checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+{{- end }}
+{{- with .Values.deployment.podAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/variant-handler/templates/deployment.yaml
+++ b/charts/variant-handler/templates/deployment.yaml
@@ -17,10 +17,8 @@ spec:
     metadata:
       labels:
         {{- $selectorLabels | nindent 8 }}
-      {{- with .Values.deployment.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "chart.podAnnotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true


### PR DESCRIPTION
# Description

Added hash of all config maps and secrets as annotations to pods so that an app's pods will be redeployed when configVars or secretVars are updated.

Fixes [#8](https://usxtech.atlassian.net/browse/CLOUD-8)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
