### PR TITLE
variant-handler - remove unused envVars, allow any type of probe

### DIFF
--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -48,7 +48,7 @@ checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha
 {{- end }}
 checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
 {{- range .Values.configMaps }}
-checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+checksum/{{ . | trunc 53 | trimSuffix "-" }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
 {{- end }}
 {{- with .Values.deployment.podAnnotations }}
 {{ toYaml . }}

--- a/charts/variant-cron/templates/_helpers.tpl
+++ b/charts/variant-cron/templates/_helpers.tpl
@@ -48,7 +48,7 @@ checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha
 {{- end }}
 checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
 {{- range .Values.configMaps }}
-checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+checksum/{{ . | trunc 53 | trimSuffix "-" }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
 {{- end }}
 {{- with .Values.podAnnotations }}
 {{ toYaml . }}

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.1
+version: 1.1.2
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 
@@ -24,8 +24,10 @@ A Helm chart for kubernetes handler
 | deployment.resources.limits.memory | string | `"768Mi"` | (string) Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | (float) Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | (string) Request memory |
+| livenessProbe | string | `nil` | See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs |
 | nodeSelector | object | `{}` | (map) Node labels for pod assignment |
 | podSecurityContext.fsGroup | int | `65534` | Groups of nobody |
+| readinessProbe | string | `nil` | See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs |
 | replicaCount | int | `1` | replicatCount |
 | revision | string | `"abc"` | (string) Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision`  that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
 | secretVars | object | `{}` | (map) User defined secret variables are implemented here. |

--- a/charts/variant-handler/ci/default-values.yaml
+++ b/charts/variant-handler/ci/default-values.yaml
@@ -11,3 +11,15 @@ podSecurityContext:
   fsGroup: 65534
 
 securityContext: {}
+
+livenessProbe:
+  exec:
+    command:
+      - /bin/echo
+      - "hello liveness"
+
+readinessProbe:
+  exec:
+    command:
+      - /bin/echo
+      - "hello readiness"

--- a/charts/variant-handler/ci/unit/defaults.yaml
+++ b/charts/variant-handler/ci/unit/defaults.yaml
@@ -6,6 +6,16 @@ tests:
     set:
       deployment.image.tag: tag
       revision: abc
+      livenessProbe:
+        exec:
+          command:
+            - /bin/echo
+            - "hello liveness"
+      readinessProbe:
+        exec:
+          command:
+            - /bin/echo
+            - "hello readiness"
     asserts:
       - template: service.yaml
         containsDocument:

--- a/charts/variant-handler/templates/_helpers.tpl
+++ b/charts/variant-handler/templates/_helpers.tpl
@@ -44,7 +44,7 @@ checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha
 {{- end }}
 checksum/serviceaccount: {{ include (print $.Template.BasePath "/serviceaccount.yaml") . | sha256sum }}
 {{- range .Values.configMaps }}
-checksum/{{ . }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
+checksum/{{ . | trunc 53 | trimSuffix "-" }}: {{ print (lookup "v1" "ConfigMap" $.Release.Namespace . ) | sha256sum }}
 {{- end }}
 {{- with .Values.deployment.podAnnotations }}
 {{ toYaml . }}

--- a/charts/variant-handler/templates/deployment.yaml
+++ b/charts/variant-handler/templates/deployment.yaml
@@ -78,40 +78,13 @@ spec:
               containerPort: {{ .Values.service.healthCheckPort }}
               protocol: TCP
             {{- end }}
-          {{ $port := ternary "http" "health" (empty .Values.service.healthCheckPort) }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.service.healthCheckPath }}
-              port: {{ $port }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.service.healthCheckPath }}
-              port: {{ $port }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
+          livenessProbe: {{ required "livenessProbe is required" .Values.livenessProbe | toYaml | nindent 12 }}
+          readinessProbe: {{ required "readinessProbe is required" .Values.readinessProbe | toYaml | nindent 12 }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           env:
             - name: REVISION
               value: {{ required "revision is required" .Values.revision | quote }}
-            {{- $secretName := (printf "%s-%s" (include "chart.fullname" .) "secret") -}}
-            {{- range $key, $value := .Values.secretVars }}
-            - name: {{ $key | quote }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: {{ $key }}
-            {{- end }}
-            {{- $configMapName := (printf "%s-%s" (include "chart.fullname" .) "config") -}}
-            {{- range $key, $value := .Values.configsVars }}
-            - name: {{ $key | quote }}
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $configMapName }}
-                  key: {{ $key }}
-            {{- end }}
           {{- if len $secrets }}
           volumeMounts:
             {{- range $secrets }}

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -109,3 +109,9 @@ tolerations: []
 # -- (map) Affinity for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+# -- See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs
+readinessProbe:
+
+# -- See [Probe](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) docs
+livenessProbe:


### PR DESCRIPTION
# Description

- removed redundant environment variable code in variant-handler
- require any type of probe for variant-handler instead of forcing HTTP probe

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Integration testing in https://github.com/variant-inc/xpress-technologies-broker

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
