### PR TITLE
F/cloud 1546 external secret dict

### DIFF
--- a/charts/library/templates/_external-secret.tpl
+++ b/charts/library/templates/_external-secret.tpl
@@ -1,4 +1,3 @@
-{{- define "library.external-secret.tpl" }}
 {{- $fullName := (include "library.chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
 {{- $secrets := .Values.awsSecrets -}}
@@ -12,8 +11,6 @@ metadata:
     {{- $labels | nindent 4 }}
 spec:
   backendType: secretsManager
-  data:
-    - key: {{ required "name is required for each secret" .name }}
-      name: {{ .name }}
+  dataFrom:
+    - {{.name}}
 {{- end -}}
-{{- end }}

--- a/charts/library/templates/_external-secret.tpl
+++ b/charts/library/templates/_external-secret.tpl
@@ -1,3 +1,4 @@
+{{- define "library.external-secret.tpl" }}
 {{- $fullName := (include "library.chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
 {{- $secrets := .Values.awsSecrets -}}
@@ -14,3 +15,4 @@ spec:
   dataFrom:
     - {{.name}}
 {{- end -}}
+{{- end }}


### PR DESCRIPTION
# Description

Updated to external secrets to be key/value pair in secrets.

[1546](https://drivevariant.atlassian.net/browse/CLOUD-1546)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [x] Sanity Testing
  - Test Case 1
    - Git clone https://github.com/variant-inc/lazy-helm-charts
    - Checkout branch
    - Cd charts/variant-api
    - `helm dependency update`
    - `helm install coolapi  . -n demo --values ci/default-values.yaml --render-subchart-notes`
    - See Lens>Secrets> cool-api-devops-playgorunds-rds-creds
    - See Key/Value pairs shown as below
    - helm uninstall coolapi -n demo
    
    ![Screen Shot 2022-04-08 at 2 15 17 PM](https://user-images.githubusercontent.com/85500202/162498682-d3522136-50d5-41dd-866a-08d052ff7bbd.png)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
