### PR TITLE
[CLOUD-1720] removed /doc and /redoc endpoints

### DIFF
--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -150,8 +150,6 @@ URL Formats
 When using public ingess, the following URL prefixes are rerouted to the root URL and are essentially blocked. They must be accessed internally, or through VPN. You can add to this list in Values.istio.ingress.redirects.
 
 - health
-- docs
-- redoc
 - swagger
 - swaggerui
 

--- a/charts/variant-api/README.md.gotmpl
+++ b/charts/variant-api/README.md.gotmpl
@@ -108,8 +108,6 @@ URL Formats
 When using public ingess, the following URL prefixes are rerouted to the root URL and are essentially blocked. They must be accessed internally, or through VPN. You can add to this list in Values.istio.ingress.redirects.
 
 - health
-- docs
-- redoc
 - swagger
 - swaggerui
 

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -17,8 +17,6 @@ The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fu
 {{- end }}
 {{- end }}
 /{{ .Release.Namespace }}/{{ $fullName }}/health
-/{{ .Release.Namespace }}/{{ $fullName }}/docs
-/{{ .Release.Namespace }}/{{ $fullName }}/redoc
 /{{ .Release.Namespace }}/{{ $fullName }}/swagger
 /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
 {{- end}}

--- a/charts/variant-api/templates/virtual-service.yaml
+++ b/charts/variant-api/templates/virtual-service.yaml
@@ -75,10 +75,6 @@ spec:
         - uri:
             prefix: /{{ $release.Namespace }}/{{ $release.Name }}/health
         - uri:
-            prefix: /{{ $release.Namespace }}/{{ $release.Name }}/docs
-        - uri:
-            prefix: /{{ $release.Namespace }}/{{ $release.Name }}/redoc
-        - uri:
             prefix: /{{ $release.Namespace }}/{{ $release.Name }}/swagger
         - uri:
             prefix: /{{ $release.Namespace }}/{{ $release.Name }}/swaggerui
@@ -120,10 +116,6 @@ spec:
       {{- end }}
         - uri:
             prefix: /health
-        - uri:
-            prefix: /docs
-        - uri:
-            prefix: /redoc
         - uri:
             prefix: /swagger
         - uri:

--- a/charts/variant-ui/templates/virtual-service.yaml
+++ b/charts/variant-ui/templates/virtual-service.yaml
@@ -42,10 +42,6 @@ spec:
         - uri:
             prefix: /health
         - uri:
-            prefix: /docs
-        - uri:
-            prefix: /redoc
-        - uri:
             prefix: /swagger
         - uri:
             prefix: /swaggerui


### PR DESCRIPTION
# Description

Removed /doc and /redoc endpoints

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x ] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
