### PR TITLE
[CLOUD-1649] reconfigured checkov to loop over charts and use each ci…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
       - id: checkov
         name: checkov
         description: runs checkov
-        entry: bash -c 'checkov -d . --framework helm kubernetes json'
-        language: system
+        entry: scripts/linters/checkov.sh
+        language: script

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -29,14 +29,11 @@ skip_checks=(
 
 # join the array of checks to skipchecks with a comma
 printf -v skipchecks "%s," "${skip_checks[@]}"
-$skipchecks=${skipchecks%?} #we remove the last newline if needed
 
 # execute checkov
 for c in "${charts[@]}"; do
     checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
     --framework helm \
     --quiet \
-    --skip-check $skipchecks
+    --skip-check "$skipchecks"
 done;
-
-exit 0

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -11,24 +11,24 @@ IFS=$'\n' charts=($dirs)
 set +o noglob
 
 # array of all checks we want to skip
-skip_checks=(
-    CKV_K8S_23
-    CKV_K8S_35
-    CKV_K8S_14
-    CKV_K8S_20
-    CKV_K8S_28
-    CKV_K8S_15
-    CKV_K8S_40
-    CKV_K8S_31
-    CKV_K8S_22
-    CKV_K8S_37
-    CKV_K8S_38
-    CKV_K8S_43
-    CKV_K8S_21
-    )
+# skip_checks=(
+#     CKV_K8S_23
+#     CKV_K8S_35
+#     CKV_K8S_14
+#     CKV_K8S_20
+#     CKV_K8S_28
+#     CKV_K8S_15
+#     CKV_K8S_40
+#     CKV_K8S_31
+#     CKV_K8S_22
+#     CKV_K8S_37
+#     CKV_K8S_38
+#     CKV_K8S_43
+#     CKV_K8S_21
+#     )
 
 # join the array of checks to skipchecks with a comma
-printf -v skipchecks "%s," "${skip_checks[@]}"
+#printf -v skipchecks "%s," "${skip_checks[@]}"
 
 error_sum=0 # total of all all error codes
 
@@ -37,11 +37,11 @@ for c in "${charts[@]}"; do
     checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
     --framework helm \
     --quiet \
-    --skip-check $skipchecks
+    --skip-check CKV_K8S_23,CKV_K8S_35,CKV_K8S_14,CKV_K8S_20,CKV_K8S_28,CKV_K8S_15,CKV_K8S_40,CKV_K8S_31,CKV_K8S_22,CKV_K8S_37,CKV_K8S_38,CKV_K8S_43,CKV_K8S_21
 
     #track any checkov errors
     ((error_sum=error_sum+$?))
-done;
+done
 
 if [ $error_sum -ne 0 ]; then
     echo "Checkov failed for some charts"

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -30,10 +30,23 @@ skip_checks=(
 # join the array of checks to skipchecks with a comma
 printf -v skipchecks "%s," "${skip_checks[@]}"
 
+error_sum=0 # total of all all error codes
+
 # execute checkov
 for c in "${charts[@]}"; do
     checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
     --framework helm \
     --quiet \
-    --skip-check $skipchecks 2> /dev/null
+    --skip-check $skipchecks
+
+    #track any checkov errors
+    ((error_sum=error_sum+$?))
 done;
+
+if [ $error_sum -ne 0 ]; then
+    echo "Checkov failed for some charts"
+    exit 1
+fi
+
+# exit cleanly if no checkov errors occurred
+exit 0

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+declare -a charts
+
+# get all chart directory paths
+dirs=$(find charts -type d -iname "variant-*")
+
+# create an array of all the chart paths
+set -o noglob
+IFS=$'\n' charts=($dirs)
+set +o noglob
+
+# array of all checks we want to skip
+skip_checks=(
+    CKV_K8S_23
+    CKV_K8S_35
+    CKV_K8S_14
+    CKV_K8S_20
+    CKV_K8S_28
+    CKV_K8S_15
+    CKV_K8S_40
+    CKV_K8S_31
+    CKV_K8S_22
+    CKV_K8S_37
+    CKV_K8S_38
+    CKV_K8S_43
+    CKV_K8S_21
+    )
+
+# join the array of checks to skipchecks with a comma
+printf -v skipchecks "%s," "${skip_checks[@]}"
+$skipchecks=${skipchecks%?} #we remove the last newline if needed
+
+# execute checkov
+for c in "${charts[@]}"; do
+    checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
+    --framework helm \
+    --quiet \
+    --skip-check $skipchecks
+done;
+
+exit 0

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -35,5 +35,5 @@ for c in "${charts[@]}"; do
     checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
     --framework helm \
     --quiet \
-    --skip-check $skipchecks
+    --skip-check $skipchecks && true
 done;

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -34,13 +34,15 @@ error_sum=0 # total of all all error codes
 
 # execute checkov
 for c in "${charts[@]}"; do
-    checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
-    --framework helm \
-    --quiet \
-    --skip-check CKV_K8S_23,CKV_K8S_35,CKV_K8S_14,CKV_K8S_20,CKV_K8S_28,CKV_K8S_15,CKV_K8S_40,CKV_K8S_31,CKV_K8S_22,CKV_K8S_37,CKV_K8S_38,CKV_K8S_43,CKV_K8S_21
+checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
+--framework helm \
+--quiet \
+--skip-check CKV_K8S_23,CKV_K8S_35,CKV_K8S_14,CKV_K8S_20,CKV_K8S_28,CKV_K8S_15,CKV_K8S_40,CKV_K8S_31,CKV_K8S_22,CKV_K8S_37,CKV_K8S_38,CKV_K8S_43,CKV_K8S_21
 
-    #track any checkov errors
-    ((error_sum=error_sum+$?))
+#track any checkov errors
+((error_sum=error_sum+$?))
+
+sleep 1
 done
 
 if [ $error_sum -ne 0 ]; then

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -35,5 +35,5 @@ for c in "${charts[@]}"; do
     checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
     --framework helm \
     --quiet \
-    --skip-check "$skipchecks"
+    --skip-check $skipchecks
 done;

--- a/scripts/linters/checkov.sh
+++ b/scripts/linters/checkov.sh
@@ -35,5 +35,5 @@ for c in "${charts[@]}"; do
     checkov -d "$c" --var-file "$c/ci/default-values.yaml" \
     --framework helm \
     --quiet \
-    --skip-check $skipchecks && true
+    --skip-check $skipchecks 2> /dev/null
 done;


### PR DESCRIPTION
…/default-values.yaml for the testing

# Description

Corrected checkov in pre-commit to use the ci/default-values.yaml in each chart's directory. The checkov tests run `helm template` in the background to do the testing. Without a values file passed in, the templating fails for values that are not defaulted. This corrects the issue.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Pre reqs:
- install `checkov` on your system, for MacOS, it is `brew install checkov`

Test Case 1 [Positive test case locally]:
- Steps
  - Create a branch based on this branch
  - Run `pre-commit run -a` locally
- Result
 - The entire pre-commit succeeds for helm doc, helm lint, and checkov

Test Case 2 [Negative test case locally]:
- Steps
  - On the local branch that was created, remove `,CKV_K8S_21` from the `skip_checks`  array in scripts/linters/checkov.sh
  - Run `pre-commit run -a` locally
- Result
 - This error will result and the pre-commit will fail: `Check: CKV_K8S_21: "The default namespace should not be used"`

Test Case 3 [Positive test case: remote]:
- Steps
  - On local branch that was created, restore `,CKV_K8S_21` to the `skip_checks` array 
  - commit and push the change
- Result
 - The CI action will succeed `https://github.com/variant-inc/lazy-helm-charts/actions/runs/2236102826`

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
