### PR TITLE
[CLOUD-1735] updated links to point to dx-docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dependencies:
           port: "{{ .Values.global.port }}"
 ```
 
-### Pull the depency chart and Install
+### Pull the dependency chart and Install
 
 `helm dependency update`
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -7,11 +7,11 @@ A Helm chart for APIs to Variant clusters
 ### What this chart provides to you by default
 
 - An API that is reachable only via [OpenVPN](https://usxtech.atlassian.net/wiki/spaces/CLOUD/pages/1332445185/How+to+configure+OpenVPN+using+Okta+SSO+to+access+USX+Variant+Resources), or by other services inside the same cluster
-  - See [ingress confguration](#ingress-configuration) to make it public, and for information regarding the generated URLs
+  - See [ingress configuration](#ingress-configuration) to make it public, and for information regarding the generated URLs
 - An API that can only reach [these services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) or other services inside the same cluster, **by default**
-  - See [egress configuration](#egress-configuration) to whitelist services you need to reach outside of the cluster
+  - See [egress configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress) to whitelist services you need to reach outside of the cluster
 - An API that is isolated from infrastructure access - Amazon services are firewall whitelisted by default, but you still need an AWS role if you need access to AWS services (SQS, SNS, RDS, etc.)
-  - See [infrastructure permissions](#infrastructure-permissions)
+  - See [infrastructure permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
 ### How do I access my API?
 
@@ -41,7 +41,7 @@ A Helm chart for APIs to Variant clusters
    - [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics collection endpoint via `GET /metrics`
-   - This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   - This chart configures a ServiceMonitor (see [Application Configuration](#application-configuration)) to collect metrics from your API
    - Middleware exists for most major API frameworks that provide a useful out-of-the box HTTP server metrics, and simple tools to push custom metrics for your product:
      - [.NET](https://github.com/prometheus-net/prometheus-net)
      - Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
@@ -59,7 +59,7 @@ A Helm chart for APIs to Variant clusters
 
 # Create Your Chart
 
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -77,7 +77,8 @@ A Helm chart for APIs to Variant clusters
 | deployment.envVars | Deployment | List variables defined in a Pod configuration that overrides any environment variables specified in the container image. | [] |
 | deployment.conditionalEnvVars | Deployment | List of Conditional Env Vars denoted by conditional (bool) | [] |
 
-#### Ingress Configuration (*how resources will access your API*)
+#### Ingress Configuration
+(*how resources will access your API*)
 
 URL Formats
 
@@ -90,11 +91,12 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - swagger
 - swaggerui
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your API will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress)
+(*how your API will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 
 ## Kubernetes Object Reference
 
@@ -113,14 +115,14 @@ All possible objects created by this chart:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | (map) Affinity for pod assignment. [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| authentication | object | `{"enabled":false}` | (bool) selecting authentication: true when defining an api resource, [Istio RBAC](https://istio.io/v1.3/docs/reference/config/authorization/istio.rbac.v1alpha1/) resources are created  to require a valid JWT token before forwarding a request to your API. [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) |
+| authentication | object | `{"enabled":false}` | (bool) selecting authentication: true when defining an api resource, [Istio RBAC](https://istio.io/v1.3/docs/reference/config/authorization/istio.rbac.v1alpha1/) resources are created  to require a valid JWT token before forwarding a request to your API. [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) |
 | authorization | object | `{"rules":{"to":[]}}` | (list) List of operation objects with methods and paths key values allowing certain methods and paths to be whitelisted within the cluster GET /health and Get /metrics are set by default in authorization.yaml |
-| autoscaling.maxReplicas | int | `5` | (int) Maximum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.minReplicas | int | `1` | (int) Minimum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | (int) CPU Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Memory Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name}. See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details. |
-| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| autoscaling.maxReplicas | int | `5` | (int) Maximum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/) |
+| autoscaling.minReplicas | int | `1` | (int) Minimum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/) |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | (int) CPU Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/) |
+| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Memory Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/) |
+| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name}. See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/) for more details. |
+| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/) |
 | deployment.args | list | `[]` | (list) List of arguments that can be passed in the image. |
 | deployment.conditionalEnvVars | list | `[]` | (list) List of Conditional Env Vars denoted by conditional (bool) and envVars (list) |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | (string) IfNotPresent, Always, Never |
@@ -130,16 +132,16 @@ All possible objects created by this chart:
 | deployment.resources.limits.memory | string | `"768Mi"` | (string) Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | (float) Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | (string) Request memory |
-| istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) and [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more details. |
+| istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress/) and [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) for more details. |
 | istio.ingress.disableRewrite | bool | `false` | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` |
-| istio.ingress.host | string | `nil` | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/). See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details. |
-| istio.ingress.public | bool | `false` | When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*. When `true`, an additional publicly accessible URL will be created. This API should be secured behind some authentication method when set to `true`. See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details. |
+| istio.ingress.host | string | `nil` | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/). See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) for more Istio details. |
+| istio.ingress.public | bool | `false` | When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*. When `true`, an additional publicly accessible URL will be created. This API should be secured behind some authentication method when set to `true`. See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) for more Istio details. |
 | istio.ingress.redirects | list | `[]` | Optional paths that will always redirect to internal/VPN endpoints |
-| livenessProbe | object | `{}` | (map) Indicates whether container is running. See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md) |
-| nodeSelector | object | `{}` | (map) Node labels for pod assignment. [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md) |
-| readinessProbe | object | `{}` | (map) Indicates whether container is ready for requests. See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md) |
+| livenessProbe | object | `{}` | (map) Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes/) |
+| nodeSelector | object | `{}` | (map) Node labels for pod assignment. [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector/) |
+| readinessProbe | object | `{}` | (map) Indicates whether container is ready for requests. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes/) |
 | revision | string | `nil` | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
-| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/) |
 | securityContext.allowPrivilegeEscalation | bool | `false` | (bool) Setting it to false ensures that no child process of a container can gain more privileges than its parent |
 | securityContext.capabilities | object | `{"drop":["ALL"]}` | Drop All capabilities |
 | securityContext.readOnlyRootFilesystem | bool | `false` | (bool) Requires that containers must run with a read-only root filesystem (i.e. no writable layer) |
@@ -149,8 +151,8 @@ All possible objects created by this chart:
 | service.metricsPort | string | `nil` | Optional port which serves prometheus metrics endpoint at `/metrics` Defaults to value of `service.targetPort` if not defined. |
 | service.port | int | `80` | Port for internal services to access your API |
 | service.targetPort | int | `9000` | Port on your container that exposes your HTTP API |
-| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application. If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md) |
+| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application. If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn/) |
 | serviceMonitor.interval | string | `"10s"` | Frequency at which Prometheus metrics will be collected from your service |
 | serviceMonitor.scrapeTimeout | string | `"10s"` | Maximum wait duration for Prometheus metrics response from your service |
 | tags | object | `{}` | (map) Deployment tags |
-| tolerations | list | `[]` | (list) Tolerations for pod assignment. [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md) |
+| tolerations | list | `[]` | (list) Tolerations for pod assignment. [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations/) |

--- a/charts/variant-api/README.md.gotmpl
+++ b/charts/variant-api/README.md.gotmpl
@@ -9,11 +9,11 @@
 ### What this chart provides to you by default
 
 - An API that is reachable only via [OpenVPN](https://usxtech.atlassian.net/wiki/spaces/CLOUD/pages/1332445185/How+to+configure+OpenVPN+using+Okta+SSO+to+access+USX+Variant+Resources), or by other services inside the same cluster
-  - See [ingress confguration](#ingress-configuration) to make it public, and for information regarding the generated URLs
+  - See [ingress configuration](#ingress-configuration) to make it public, and for information regarding the generated URLs
 - An API that can only reach [these services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) or other services inside the same cluster, **by default**
-  - See [egress configuration](#egress-configuration) to whitelist services you need to reach outside of the cluster
+  - See [egress configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress) to whitelist services you need to reach outside of the cluster
 - An API that is isolated from infrastructure access - Amazon services are firewall whitelisted by default, but you still need an AWS role if you need access to AWS services (SQS, SNS, RDS, etc.)
-  - See [infrastructure permissions](#infrastructure-permissions)
+  - See [infrastructure permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
 ### How do I access my API?
 
@@ -43,7 +43,7 @@
    - [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics collection endpoint via `GET /metrics`
-   - This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   - This chart configures a ServiceMonitor (see [Application Configuration](#application-configuration)) to collect metrics from your API
    - Middleware exists for most major API frameworks that provide a useful out-of-the box HTTP server metrics, and simple tools to push custom metrics for your product:
      - [.NET](https://github.com/prometheus-net/prometheus-net)
      - Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
@@ -61,7 +61,7 @@
 
 # Create Your Chart
 
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -80,7 +80,8 @@
 | deployment.envVars | Deployment | List variables defined in a Pod configuration that overrides any environment variables specified in the container image. | [] |
 | deployment.conditionalEnvVars | Deployment | List of Conditional Env Vars denoted by conditional (bool) | [] |
 
-#### Ingress Configuration (*how resources will access your API*)
+#### Ingress Configuration
+(*how resources will access your API*)
 
 URL Formats
 
@@ -93,11 +94,12 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - swagger
 - swaggerui
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your API will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress)
+(*how your API will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 
 ## Kubernetes Object Reference
 

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -5,12 +5,12 @@ istio:
     # -- (string) The base domain that will be used to construct URLs that point to your API.
     # This should almost always be the Octopus Variable named `DOMAIN` in the
     # [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/).
-    # See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details.
+    # See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) for more Istio details.
     host:
     # -- When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*.
     # When `true`, an additional publicly accessible URL will be created.
     # This API should be secured behind some authentication method when set to `true`.
-    # See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details.
+    # See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) for more Istio details.
     public: false
     # -- When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false`
     disableRewrite: false
@@ -20,8 +20,8 @@ istio:
   # -- A whitelist of external services that your API requires connection to.
   # The whitelist applies to the entire namespace in which this chart is installed.
   # [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration.
-  # See [egress](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) and
-  # [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more details.
+  # See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress/) and
+  # [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/) for more details.
   egress: []
     # - name: some-external-api
     #   hosts:
@@ -58,18 +58,18 @@ serviceAccount:
   # -- (string) Optional ARN of the IAM role to be assumed by your application.
   # If your API requires access to any AWS services, a role should be created in AWS IAM.
   # This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.).
-  # [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+  # [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn/)
   roleArn:
 
 
 autoscaling:
-  # -- (int) Minimum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Minimum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/)
   minReplicas: 1
-  # -- (int) Maximum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Maximum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/)
   maxReplicas: 5
-  # -- (int) CPU Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) CPU Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/)
   targetCPUUtilizationPercentage: 80
-  # -- (int) Memory Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Memory Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling/)
   targetMemoryUtilizationPercentage:
 
 deployment:
@@ -111,7 +111,7 @@ deployment:
 # -- A list of secrets to configure to make available to your API.
 # Create your secret in AWS Secrets Manager as plain text.
 # Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name}.
-# See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details.
+# See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/) for more details.
 awsSecrets: []
   # - name: eng-secret-in-aws
 
@@ -123,7 +123,7 @@ revision:
 # -- (bool) selecting authentication: true when defining an api resource,
 # [Istio RBAC](https://istio.io/v1.3/docs/reference/config/authorization/istio.rbac.v1alpha1/) resources are created
 #  to require a valid JWT token before forwarding a request to your API.
-# [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md)
+# [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio/)
 authentication:
   enabled: false
 
@@ -137,21 +137,21 @@ authorization:
       #     paths: "/swagger"
 
 # -- (map) User defined secret variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/)
 secretVars: {}
   # foo: bar
 
 # -- (map) User defined environment variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/)
 configVars: {}
   # bar: foo
 
 # -- (map) Node labels for pod assignment.
-# [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md)
+# [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector/)
 nodeSelector: {}
 
 # -- (list) Tolerations for pod assignment.
-# [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md)
+# [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations/)
 tolerations: []
 
 # -- (map) Affinity for pod assignment.
@@ -173,14 +173,14 @@ securityContext:
   readOnlyRootFilesystem: false
 
 # -- (map) Indicates whether container is ready for requests.
-# See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md)
+# See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes/)
 readinessProbe: {}
 #   httpGet:
 #     path: /health
 #     port: 5000
 
 # -- (map) Indicates whether container is running.
-# See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md)
+# See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes/)
 livenessProbe: {}
 #   httpGet:
 #     path: /health

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -32,7 +32,7 @@ A Helm chart for Istio Objects
 ***
 
 # Create Your Chart
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -46,7 +46,7 @@ A Helm chart for Istio Objects
   node:
     # Set to true to create custom nodes. Default is false
     create: true
-    # EC2 Instance type for your cusom node. Default is r5.xlarge
+    # EC2 Instance type for your custom node. Default is r5.xlarge
     instanceType: r5.xlarge
     # If nil, the feature is disabled, nodes will never expire
     ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
@@ -54,11 +54,12 @@ A Helm chart for Istio Objects
     ttlSecondsAfterEmpty: 1800
 ```
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn/)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your Cron Job will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress/)
+(*how your Cron Job will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/)
 
 ## Kubernetes Object Reference
 
@@ -76,8 +77,8 @@ All possible objects created by this chart:
 |-----|------|---------|-------------|
 | CLUSTER_NAME | string | `"variant-dev"` | For securityGroupSelector in provisioner.yaml |
 | affinity | object | `{}` | Affinity for pod assignment [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name} See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details. |
-| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name} See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) for more details. |
+| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) |
 | cronJob.command | list | `nil` | full path to the job script to execute. https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ |
 | cronJob.image.pullPolicy | string | `"Always"` | (string) IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
@@ -89,21 +90,21 @@ All possible objects created by this chart:
 | cronJob.schedule | string | `nil` | Cron Style Schedule. For help check https://crontab.guru/ |
 | cronJob.suspend | bool | `false` | (bool) https://kubernetes.io/blog/2021/04/12/introducing-suspended-jobs/ |
 | imagePullSecrets | list | `[]` | (list) https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
-| istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md). See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details. |
+| istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress). See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more Istio details. |
 | node.create | bool | `false` | Flag to determine whether or not custom nodes will be provisioned. |
 | node.instanceType | string | `nil` | The EC2 Instance Type for your custom nodes. |
 | node.ttlSecondsAfterEmpty | int | `3600` | Number of seconds before custom nodes will be removed if nothing is running on them. |
 | node.ttlSecondsUntilExpired | string | `nil` | If nil, the feature is disabled, nodes will never expire |
-| nodeSelector | object | `{}` | Node labels for pod assignment [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md) |
+| nodeSelector | object | `{}` | Node labels for pod assignment [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector) |
 | podSecurityContext.fsGroup | int | `65534` | Groups of nobody |
 | restartPolicy | string | `"Never"` | Use Never by default for jobs so new pod is created on failure instead of restarting containers |
 | revision | string | `nil` | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
-| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) |
 | securityContext.allowPrivilegeEscalation | bool | `false` | (bool) Setting it to false ensures that no child process of a container can gain more privileges than its parent |
 | securityContext.capabilities | object | `{"drop":["ALL"]}` | Drop All capabilities |
 | securityContext.readOnlyRootFilesystem | bool | `false` | (bool) Requires that containers must run with a read-only root filesystem (i.e. no writable layer) |
 | securityContext.runAsNonRoot | bool | `true` | Runs as non root. Must use numeric User in container |
 | securityContext.runAsUser | int | `nil` | Runs as numeric user |
-| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application. If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md) |
-| tags | string | `nil` | Tags to be applied to custom node provisioner and labels |
-| tolerations | list | `[]` | Tolerations for pod assignment [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md) |
+| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application. If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn) |
+| tags | object | `{}` | Tags to be applied to custom node provisioner and labels |
+| tolerations | list | `[]` | Tolerations for pod assignment [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations) |

--- a/charts/variant-cron/README.md.gotmpl
+++ b/charts/variant-cron/README.md.gotmpl
@@ -18,7 +18,7 @@
    - [.NET](https://github.com/variant-inc/actions-dotnet)
    - [Node](https://github.com/variant-inc/actions-nodejs)
    - [Python](https://github.com/variant-inc/actions-python)
-2. Make sure curl utility is available in the image as it is used to check the status of the sidecar container. If not available, Based on the image you use add below commands in the Dockerfile. 
+2. Make sure curl utility is available in the image as it is used to check the status of the sidecar container. If not available, Based on the image you use add below commands in the Dockerfile.
    - Ubuntu / Debian OS
      ```bash
      RUN apt-get install curl
@@ -34,7 +34,7 @@
 ***
 
 # Create Your Chart
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -48,7 +48,7 @@
   node:
     # Set to true to create custom nodes. Default is false
     create: true
-    # EC2 Instance type for your cusom node. Default is r5.xlarge
+    # EC2 Instance type for your custom node. Default is r5.xlarge
     instanceType: r5.xlarge
     # If nil, the feature is disabled, nodes will never expire
     ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
@@ -56,11 +56,12 @@
     ttlSecondsAfterEmpty: 1800
 ```
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn/)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your Cron Job will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress/)
+(*how your Cron Job will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets/)
 
 ## Kubernetes Object Reference
 

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -4,8 +4,8 @@ istio:
   # -- A whitelist of external services that your API requires connection to.
   # The whitelist applies to the entire namespace in which this chart is installed.
   # [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration.
-  # See [egress](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md).
-  # See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details.
+  # See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress).
+  # See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more Istio details.
   egress: []
     # - name: some-external-api
     #   hosts:
@@ -27,7 +27,7 @@ serviceAccount:
   # -- (string) Optional ARN of the IAM role to be assumed by your application.
   # If your API requires access to any AWS services, a role should be created in AWS IAM.
   # This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.).
-  # [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+  # [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
   roleArn:
 
 podSecurityContext:
@@ -78,17 +78,17 @@ cronJob:
 # -- A list of secrets to configure to make available to your API.
 # Create your secret in AWS Secrets Manager as plain text.
 # Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name}
-# See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details.
+# See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) for more details.
 awsSecrets: []
   # - name: eng-secret-in-aws
 
 # -- (map) User defined secret variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 secretVars: {}
   # key: value
 
 # -- (map) User defined environment variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 configVars: {}
   # key: value
 
@@ -99,11 +99,11 @@ revision:
   # test-latest
 
 # -- Node labels for pod assignment
-# [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md)
+# [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector)
 nodeSelector: {}
 
 # --  Tolerations for pod assignment
-# [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md)
+# [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations)
 tolerations: []
 
 # -- Affinity for pod assignment
@@ -125,7 +125,7 @@ node:
 CLUSTER_NAME: variant-dev
 
 # -- Tags to be applied to custom node provisioner and labels
-tags:
+tags: {}
 
 # -- Use Never by default for jobs so new pod is created on failure instead of restarting containers
 restartPolicy: Never

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -8,10 +8,10 @@ A Helm chart for kubernetes handler
 
 - A chart to deploy a handler image to Kubernetes -- the Variant,
   CloudOps-approved way.
-- An handler that is isolated from infrastructure access - Amazon services are
+- A handler that is isolated from infrastructure access - Amazon services are
   firewall whitelisted by default, but you still need an AWS role if you need
   access to AWS services (SQS, SNS, RDS, etc.)
-  - See [infrastructure permissions](#infrastructure-permissions)
+  - See [infrastructure permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
 ## Before you start
 
@@ -23,7 +23,7 @@ A Helm chart for kubernetes handler
    - [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics endpoint via `GET /metrics`
-   - This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   - This chart configures a ServiceMonitor (see [Application Configuration](#application-configuration)) to collect metrics from your API
    - Middleware exists for most major API frameworks that provide a useful out of the box HTTP server metrics, and simple tools to push custom metrics for your product:
      - [.NET](https://github.com/prometheus-net/prometheus-net)
      - Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
@@ -40,7 +40,7 @@ A Helm chart for kubernetes handler
 ***
 
 # Create Your Chart
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -58,11 +58,12 @@ A Helm chart for kubernetes handler
 | deployment.envVars | Deployment | List variables defined in a Pod configuration that overrides any environment variables specified in the container image. | [] |
 | deployment.conditionalEnvVars | Deployment | List of Conditional Env Vars denoted by conditional (bool) | [] |
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your service will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress)
+(*how your service will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 
 ## Kubernetes Object Reference
 
@@ -79,13 +80,13 @@ All possible objects created by this chart:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | (map) Affinity for pod assignment [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| autoscaling.enabled | bool | `false` | Flag to trigger HPA, Allowed values true or false. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.maxReplicas | int | `5` | (int) Maximum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.minReplicas | int | `1` | (int) Minimum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | (int) CPU Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Memory Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read. See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details. |
-| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| autoscaling.enabled | bool | `false` | Flag to trigger HPA, Allowed values true or false. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.maxReplicas | int | `5` | (int) Maximum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.minReplicas | int | `1` | (int) Minimum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | (int) CPU Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Memory Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read. See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) for more details. |
+| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) |
 | deployment.args | list | `[]` | (list) List of arguments that can be passed in the image. |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | (string) IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | (string) The full URL of the image to be deployed containing the tag |
@@ -94,22 +95,22 @@ All possible objects created by this chart:
 | deployment.resources.limits.memory | string | `"768Mi"` | (string) Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | (float) Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | (string) Request memory |
-| istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) and [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more details. |
-| livenessProbe | object | `{}` | (map) Indicates whether container is running. See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md) |
-| nodeSelector | object | `{}` | (map) Node labels for pod assignment [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md) |
+| istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress) and [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more details. |
+| livenessProbe | object | `{}` | (map) Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes) |
+| nodeSelector | object | `{}` | (map) Node labels for pod assignment [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector) |
 | podSecurityContext.fsGroup | int | `65534` | Groups of nobody |
-| readinessProbe | object | `{}` | (map) Indicates whether container is ready for requests. See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md) |
+| readinessProbe | object | `{}` | (map) Indicates whether container is ready for requests. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes) |
 | replicaCount | int | `1` | replicaCount |
 | revision | string | `"abc"` | (string) Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
-| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) |
 | securityContext | object | `{}` | (map) Security Context for containers |
 | service.healthCheckPath | string | `"/health"` | Health check URI, This will be used in probes to check container status |
 | service.healthCheckPort | string | `nil` | Optional port which serves a health check endpoint at `/health` Defaults to value of `service.targetPort` if not defined. |
 | service.metricsPort | string | `nil` | Optional port which serves prometheus metrics endpoint at `/metrics` Defaults to value of `service.targetPort` if not defined. |
 | service.port | int | `80` | Port for internal services to access your API |
 | service.targetPort | int | `9000` | Port on your container that exposes your HTTP API |
-| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application.  If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md) |
+| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application.  If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn) |
 | serviceMonitor.interval | string | `"10s"` | Frequency at which Prometheus metrics will be collected from your service |
 | serviceMonitor.scrapeTimeout | string | `"10s"` | Maximum wait duration for Prometheus metrics response from your service |
 | tags | object | `{}` | (map) Deployment tags |
-| tolerations | list | `[]` | (list) Tolerations for pod assignment [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md) |
+| tolerations | list | `[]` | (list) Tolerations for pod assignment [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations) |

--- a/charts/variant-handler/README.md.gotmpl
+++ b/charts/variant-handler/README.md.gotmpl
@@ -10,10 +10,10 @@
 
 - A chart to deploy a handler image to Kubernetes -- the Variant,
   CloudOps-approved way.
-- An handler that is isolated from infrastructure access - Amazon services are
+- A handler that is isolated from infrastructure access - Amazon services are
   firewall whitelisted by default, but you still need an AWS role if you need
   access to AWS services (SQS, SNS, RDS, etc.)
-  - See [infrastructure permissions](#infrastructure-permissions)
+  - See [infrastructure permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
 ## Before you start
 
@@ -25,7 +25,7 @@
    - [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics endpoint via `GET /metrics`
-   - This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   - This chart configures a ServiceMonitor (see [Application Configuration](#application-configuration)) to collect metrics from your API
    - Middleware exists for most major API frameworks that provide a useful out of the box HTTP server metrics, and simple tools to push custom metrics for your product:
      - [.NET](https://github.com/prometheus-net/prometheus-net)
      - Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
@@ -42,7 +42,7 @@
 ***
 
 # Create Your Chart
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -60,11 +60,12 @@
 | deployment.envVars | Deployment | List variables defined in a Pod configuration that overrides any environment variables specified in the container image. | [] |
 | deployment.conditionalEnvVars | Deployment | List of Conditional Env Vars denoted by conditional (bool) | [] |
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your service will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress)
+(*how your service will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 
 ## Kubernetes Object Reference
 

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -4,8 +4,8 @@ istio:
   # -- A whitelist of external services that your API requires connection to.
   # The whitelist applies to the entire namespace in which this chart is installed.
   # [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration.
-  # See [egress](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) and
-  # [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more details.
+  # See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress) and
+  # [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more details.
   egress: []
     # - name: some-external-api
     #   hosts:
@@ -44,7 +44,7 @@ serviceAccount:
   # -- (string) Optional ARN of the IAM role to be assumed by your application. 
   # If your API requires access to any AWS services, a role should be created in AWS IAM.
   # This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.).
-  # [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+  # [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
   roleArn:
 
 podSecurityContext:
@@ -70,15 +70,15 @@ securityContext: {}
 replicaCount: 1
 
 autoscaling:
-  # -- Flag to trigger HPA, Allowed values true or false. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- Flag to trigger HPA, Allowed values true or false. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   enabled: false
-  # -- (int) Minimum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Minimum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   minReplicas: 1
- # -- (int) Maximum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+ # -- (int) Maximum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   maxReplicas: 5
-  # -- (int) CPU Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) CPU Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   targetCPUUtilizationPercentage: 80
-  # -- (int) Memory Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Memory Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   targetMemoryUtilizationPercentage:
 
 deployment:
@@ -112,26 +112,26 @@ revision: abc
 # -- A list of secrets to configure to make available to your API.
 # Create your secret in AWS Secrets Manager as plain text.
 # Full contents of this secret will be mounted as a file your application can read.
-# See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details.
+# See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) for more details.
 awsSecrets: []
   # - name: testKey
 
 # -- (map) User defined secret variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 secretVars: {}
   # foo: bar
 
 # -- (map) User defined environment variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 configVars: {}
   # bar: foo
 
 # -- (map) Node labels for pod assignment
-# [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md)
+# [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector)
 nodeSelector: {}
 
 # -- (list) Tolerations for pod assignment
-# [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md)
+# [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations)
 tolerations: []
 
 # -- (map) Affinity for pod assignment
@@ -139,11 +139,11 @@ tolerations: []
 affinity: {}
 
 # -- (map) Indicates whether container is ready for requests.
-# See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md)
+# See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes)
 readinessProbe: {}
 
 # -- (map) Indicates whether container is running.
-# See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md)
+# See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes)
 livenessProbe: {}
 
 # -- (map) Deployment tags

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -18,7 +18,7 @@ A Helm chart for a web UI configuration
    - [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics collection endpoint via `GET /metrics`
-   - This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   - This chart configures a ServiceMonitor (see [Application Configuration](#application-configuration)) to collect metrics from your API
    - Middleware exists for most major API frameworks that provide a useful out-of-the box HTTP server metrics, and simple tools to push custom metrics for your product:
      - [.NET](https://github.com/prometheus-net/prometheus-net)
      - Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
@@ -30,12 +30,12 @@ A Helm chart for a web UI configuration
 
 1. Your API, health check endpoint, and metrics endpoint all run on the same server at port 9000
 1. Your container executes without any required arguments (i.e can be executed as `docker run [image]`)
-1. There is no required environment variable for your API to function
+1. There is no required environment variable for your UI to function
 
 ***
 
 # Create Your Chart
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -51,7 +51,8 @@ A Helm chart for a web UI configuration
 | deployment.envVars | Deployment | List variables defined in a Pod configuration that overrides any environment variables specified in the container image. | [] |
 | deployment.conditionalEnvVars | Deployment | List of Conditional Env Vars denoted by conditional (bool) | [] |
 
-#### Ingress Configuration (*how resources will access your service*)
+#### Ingress Configuration
+(*how resources will access your service*)
 
 URL Formats
 
@@ -64,11 +65,12 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - swagger
 - swaggerui
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your service will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress)
+(*how your service will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 
 #### Special Considerations
 
@@ -104,12 +106,12 @@ All possible objects created by this chart:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | (map) Affinity for pod assignment [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| autoscaling.maxReplicas | int | `5` | (int) Maximum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.minReplicas | int | `1` | (int) Minimum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | (int) CPU Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Memory Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md) |
-| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name} See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details. |
-| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| autoscaling.maxReplicas | int | `5` | (int) Maximum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.minReplicas | int | `1` | (int) Minimum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | (int) CPU Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Memory Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling) |
+| awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name} See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) for more details. |
+| configVars | object | `{}` | (map) User defined environment variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) |
 | deployment.args | list | `[]` | (list) List of arguments that can be passed in the image. |
 | deployment.conditionalEnvVars | list | `[]` | (list) List of Conditional Env Vars denoted by conditional (bool) and envVars (list) |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | (string) IfNotPresent, Always, Never |
@@ -120,17 +122,17 @@ All possible objects created by this chart:
 | deployment.resources.requests.cpu | float | `0.1` | (float) Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | (string) Request memory |
 | fullnameOverride | string | `nil` | fullnameOverride completely replaces the generated name. |
-| istio.egress | string | `nil` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details. |
+| istio.egress | string | `nil` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more Istio details. |
 | istio.ingress.disableRewrite | bool | `false` | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` |
-| istio.ingress.host | string | `nil` | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/) See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details. |
+| istio.ingress.host | string | `nil` | The base domain that will be used to construct URLs that point to your API. This should almost always be the Octopus Variable named `DOMAIN` in the [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/) See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more Istio details. |
 | istio.ingress.public | bool | `false` | When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*. When `true`, an additional publicly accessible URL will be created. This API should be secured behind some authentication method when set to `true`. |
 | istio.ingress.redirects | list | `[]` | Optional paths that will always redirect to internal/VPN endpoints |
-| livenessProbe | object | `{}` | (map) Indicates whether container is running. See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md) |
+| livenessProbe | object | `{}` | (map) Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes) |
 | nameOverride | string | `nil` | nameOverride replaces the name of the chart in the Chart.yaml file |
-| nodeSelector | object | `{}` | (map) Node labels for pod assignment [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md) |
-| readinessProbe | object | `{}` | (map) Indicates whether container is ready for requests. See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md) |
+| nodeSelector | object | `{}` | (map) Node labels for pod assignment [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector) |
+| readinessProbe | object | `{}` | (map) Indicates whether container is ready for requests. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes) |
 | revision | string | `nil` | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
-| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) |
+| secretVars | object | `{}` | (map) User defined secret variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) |
 | securityContext.allowPrivilegeEscalation | bool | `false` | (bool) Setting it to false ensures that no child process of a container can gain more privileges than its parent |
 | securityContext.capabilities | object | `{"drop":["ALL"]}` | Drop All capabilities |
 | securityContext.readOnlyRootFilesystem | bool | `false` | (bool) Requires that containers must run with a read-only root filesystem (i.e. no writable layer) |
@@ -140,11 +142,11 @@ All possible objects created by this chart:
 | service.metricsPort | string | `nil` | Optional port which serves prometheus metrics endpoint at `/metrics` Defaults to value of `service.targetPort` if not defined. |
 | service.port | int | `80` | Port for internal services to access your API |
 | service.targetPort | int | `9000` | Port on your container that exposes your HTTP API |
-| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application. If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md) |
+| serviceAccount.roleArn | string | `nil` | Optional ARN of the IAM role to be assumed by your application. If your API requires access to any AWS services, a role should be created in AWS IAM. This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.). [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn) |
 | serviceMonitor.enabled | bool | `false` | Service Monitor Enabled |
 | serviceMonitor.interval | string | `"10s"` | Query Interval |
 | serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape Timeout |
 | serviceMonitor.selector | object | `{}` | (map) Any label selector |
 | serviceMonitor.targetPort | int | `9090` | Service Monitor Target Port |
 | tags | object | `{}` | (map) Deployment tags |
-| tolerations | list | `[]` | (list) Tolerations for pod assignment [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md) |
+| tolerations | list | `[]` | (list) Tolerations for pod assignment [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations) |

--- a/charts/variant-ui/README.md.gotmpl
+++ b/charts/variant-ui/README.md.gotmpl
@@ -20,7 +20,7 @@
    - [Python](https://github.com/variant-inc/actions-python)
 1. Host a health check endpoint via `GET /health` which returns a status code < 400 when healthy or >= 400 when unhealthy
 1. Host a Prometheus metrics collection endpoint via `GET /metrics`
-   - This chart configures a ServiceMonitor (see [Object Reference](#object-reference)) to collect metrics from your API
+   - This chart configures a ServiceMonitor (see [Application Configuration](#application-configuration)) to collect metrics from your API
    - Middleware exists for most major API frameworks that provide a useful out-of-the box HTTP server metrics, and simple tools to push custom metrics for your product:
      - [.NET](https://github.com/prometheus-net/prometheus-net)
      - Node - [NestJS](https://github.com/digikare/nestjs-prom), [Express](https://github.com/joao-fontenele/express-prometheus-middleware)
@@ -32,13 +32,13 @@
 
 1. Your API, health check endpoint, and metrics endpoint all run on the same server at port 9000
 1. Your container executes without any required arguments (i.e can be executed as `docker run [image]`)
-1. There is no required environment variable for your API to function
+1. There is no required environment variable for your UI to function
 
 
 ***
 
 # Create Your Chart
-**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](../../README.md)
+**Follow This Quick Example:** [Using a lazy-helm-chart as a Subchart](https://github.com/variant-inc/lazy-helm-charts/blob/master/README.md#using-a-lazy-helm-chart-as-a-subchart)
 
 ***
 
@@ -54,7 +54,8 @@
 | deployment.envVars | Deployment | List variables defined in a Pod configuration that overrides any environment variables specified in the container image. | [] |
 | deployment.conditionalEnvVars | Deployment | List of Conditional Env Vars denoted by conditional (bool) | [] |
 
-#### Ingress Configuration (*how resources will access your service*)
+#### Ingress Configuration
+(*how resources will access your service*)
 
 URL Formats
 
@@ -67,11 +68,12 @@ When using public ingess, the following URL prefixes are rerouted to the root UR
 - swagger
 - swaggerui
 
-#### [Infrastructure Permissions](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+#### [Infrastructure Permissions](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
 
-#### [Egress Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/egress.md) (*how your service will access external resources*)
+#### [Egress Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/egress)
+(*how your service will access external resources*)
 
-#### [Secrets Configuration](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+#### [Secrets Configuration](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 
 #### Special Considerations
 

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -12,7 +12,7 @@ istio:
     # -- (string) The base domain that will be used to construct URLs that point to your API.
     # This should almost always be the Octopus Variable named `DOMAIN` in the
     # [AWS Access Keys](https://octopus.apps.ops-drivevariant.com/app#/Spaces-22/library/variables/)
-    # See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details.
+    # See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more Istio details.
     host:
     # -- When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*.
     # When `true`, an additional publicly accessible URL will be created.
@@ -26,7 +26,7 @@ istio:
   # -- A whitelist of external services that your API requires connection to.
   # The whitelist applies to the entire namespace in which this chart is installed.
   # [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration.
-  # See [Istio](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/istio.md) for more Istio details.
+  # See [Istio](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/istio) for more Istio details.
   egress:
     # ## List of hostnames and ports
     # # Hosts should be FQDN
@@ -68,17 +68,17 @@ serviceAccount:
   # -- (string) Optional ARN of the IAM role to be assumed by your application.
   # If your API requires access to any AWS services, a role should be created in AWS IAM.
   # This role should have an inline policy that describes the permissions your API needs (connect to RDS, publish to an SNS topic, read from an SQS queue, etc.).
-  # [RoleArn](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/rolearn.md)
+  # [RoleArn](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/rolearn)
   roleArn:
 
 autoscaling:
-  # -- (int) Minimum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Minimum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   minReplicas: 1
-  # -- (int) Maximum Number of Replicas. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Maximum Number of Replicas. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   maxReplicas: 5
-  # -- (int) CPU Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) CPU Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   targetCPUUtilizationPercentage: 80
-  # -- (int) Memory Utilization Percentage. [Autoscaling](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/autoscaling.md)
+  # -- (int) Memory Utilization Percentage. [Autoscaling](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/autoscaling)
   targetMemoryUtilizationPercentage:
 
 deployment:
@@ -120,7 +120,7 @@ deployment:
 # -- A list of secrets to configure to make available to your API.
 # Create your secret in AWS Secrets Manager as plain text.
 # Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name}
-# See [AWS Secrets](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md) for more details.
+# See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets) for more details.
 awsSecrets: []
   # - name: eng-secret-in-aws
 
@@ -130,20 +130,20 @@ awsSecrets: []
 revision:
 
 # -- (map) User defined secret variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 secretVars: {}
   # foo: bar
 # -- (map) User defined environment variables are implemented here.
-# [More Information](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/secrets.md)
+# [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/secrets)
 configVars: {}
   # bar: foo
 
 # -- (map) Node labels for pod assignment
-# [NodeSelector](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/nodeselector.md)
+# [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/nodeselector)
 nodeSelector: {}
 
 # -- (list) Tolerations for pod assignment
-# [Tolerations](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/tolerations.md)
+# [Tolerations](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/tolerations)
 tolerations: []
 
 # -- (map) Affinity for pod assignment
@@ -151,11 +151,11 @@ tolerations: []
 affinity: {}
 
 # -- (map) Indicates whether container is ready for requests.
-# See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md)
+# See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes)
 readinessProbe: {}
 
 # -- (map) Indicates whether container is running.
-# See [Probe](https://github.com/variant-inc/terragrunt-variant-apps/tree/master/docs/probes.md)
+# See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/apps/common/probes)
 livenessProbe: {}
 
 securityContext:


### PR DESCRIPTION
# Description

Updated links from point to terragrunt-variant-apps to dx-docs repo for BackStage documents service. Corrected some documentation typos also.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
