### PR TITLE
F/cloud 1742 selector labels

### DIFF
--- a/charts/library/templates/_chart.tpl
+++ b/charts/library/templates/_chart.tpl
@@ -25,11 +25,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 revision: {{ required "revision is required" .Values.revision | quote }}
-app: {{ .Release.Name }}
-revision: {{ required "revision is required" .Values.revision | quote }}
-{{- range $key, $value := .Values.tags }}
-cloudops.io.{{ $key }}: {{ $value | replace " " "-"| quote }}
-{{- end }}
 {{- end }}
 
 {{/*
@@ -38,4 +33,8 @@ Selector labels
 {{- define "library.chart.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app: {{ .Release.Name }}
+{{- range $key, $value := .Values.tags }}
+cloudops.io.{{ $key }}: {{ $value | replace " " "-"| quote }}
+{{- end }}
 {{- end }}

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.9-beta
+version: 2.1.9
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.8
+version: 2.1.9-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.9-beta](https://img.shields.io/badge/Version-2.1.9--beta-informational?style=flat-square)
+![Version: 2.1.9](https://img.shields.io/badge/Version-2.1.9-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.8](https://img.shields.io/badge/Version-2.1.8-informational?style=flat-square)
+![Version: 2.1.9-beta](https://img.shields.io/badge/Version-2.1.9--beta-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/templates/_helpers.tpl
+++ b/charts/variant-api/templates/_helpers.tpl
@@ -14,13 +14,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{- define "chart.ingressHostname" -}}
 {{- required "istio.ingress.host is required" .Values.istio.ingress.host }}

--- a/charts/variant-api/templates/authentication.yaml
+++ b/charts/variant-api/templates/authentication.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.authentication.enabled }}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $selectorLabels := (include "library.chart.selectorLabels" .) -}}
 apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:

--- a/charts/variant-api/templates/authorization.yaml
+++ b/charts/variant-api/templates/authorization.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.authentication.enabled }}
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $selectorLabels := (include "library.chart.selectorLabels" .) -}}
 {{- $host := (include "chart.ingressHostname" .) -}}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $selectorLabels := (include "library.chart.selectorLabels" .) -}}
 {{- $secrets := .Values.awsSecrets -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.8-beta
+version: 1.2.8
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.7
+version: 1.2.8-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.7](https://img.shields.io/badge/Version-1.2.7-informational?style=flat-square)
+![Version: 1.2.8-beta](https://img.shields.io/badge/Version-1.2.8--beta-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.8-beta](https://img.shields.io/badge/Version-1.2.8--beta-informational?style=flat-square)
+![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/templates/_helpers.tpl
+++ b/charts/variant-cron/templates/_helpers.tpl
@@ -1,5 +1,3 @@
-
-   
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -16,13 +14,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{- define "chart.ingressHostname" -}}
 {{- required "istio.ingress.host is required" .Values.istio.ingress.host }}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -1,6 +1,6 @@
 {{- define "chart.jobspec" }}
 {{- $fullName := (include "chart.fullname" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $selectorLabels := (include "library.chart.selectorLabels" .) -}}
 {{- $secrets := .Values.awsSecrets -}}
 template:
   metadata:

--- a/charts/variant-cron/templates/cron.yaml
+++ b/charts/variant-cron/templates/cron.yaml
@@ -1,6 +1,5 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.6
+version: 1.1.7-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.7-beta
+version: 1.1.7
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square)
+![Version: 1.1.7-beta](https://img.shields.io/badge/Version-1.1.7--beta-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.7-beta](https://img.shields.io/badge/Version-1.1.7--beta-informational?style=flat-square)
+![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/templates/_helpers.tpl
+++ b/charts/variant-handler/templates/_helpers.tpl
@@ -14,14 +14,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
 {{- define "chart.podAnnotations" -}}
 {{- if len .Values.configVars }}
 checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}

--- a/charts/variant-handler/templates/deployment.yaml
+++ b/charts/variant-handler/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $selectorLabels := (include "library.chart.selectorLabels" .) -}}
 {{- $secrets := .Values.awsSecrets -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.3-beta
+version: 1.4.3
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.2
+version: 1.4.3-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.3-beta](https://img.shields.io/badge/Version-1.4.3--beta-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square)
+![Version: 1.4.3-beta](https://img.shields.io/badge/Version-1.4.3--beta-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 

--- a/charts/variant-ui/templates/_helpers.tpl
+++ b/charts/variant-ui/templates/_helpers.tpl
@@ -14,14 +14,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
 {{- define "chart.ingressHostname" -}}
 {{- required "istio.ingress.host is required" .Values.istio.ingress.host }}
 {{- end }}

--- a/charts/variant-ui/templates/deployment.yaml
+++ b/charts/variant-ui/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- $labels := (include "library.chart.labels" .) -}}
-{{- $selectorLabels := (include "chart.selectorLabels" .) -}}
+{{- $selectorLabels := (include "library.chart.selectorLabels" .) -}}
 {{- $secrets := .Values.awsSecrets -}}
 {{- $secretEnv := .Values.secretVars -}}
 {{- $configEnv := .Values.configVars -}}


### PR DESCRIPTION
# Description

https://drivevariant.atlassian.net/browse/CLOUD-1742

Added to library.chart.selectorLabels
```
app: {{ .Release.Name }}
{{- range $key, $value := .Values.tags }}
cloudops.io.{{ $key }}: {{ $value | replace " " "-"| quote }}
{{- end }}
```

Removed from chart.labels
```
app: {{ .Release.Name }}
revision: {{ required "revision is required" .Values.revision | quote }}
{{- range $key, $value := .Values.tags }}
cloudops.io.{{ $key }}: {{ $value | replace " " "-"| quote }}
{{- end }}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checkout branch from: https://github.com/variant-inc/demo-python-flask-variant-api/tree/ralph/test-branch/.variant/deploy

**Update Lazy Action Octopus**
```
      - name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@v3
        env:
          IMAGE_NAME: 064859874041.dkr.ecr.us-east-1.amazonaws.com/demo/python-flask-variant-api:0.1.0-ralph-test-branc0001.81
        with:
          deploy_package_version: 1.0.1-t-cloud-1752-tes0001.396
```

- [x] Sanity Testing
### Deploy Api, Cron, Handler, Ui
Test Steps:
1. Deploy Api, Cron, Handler, Ui
2. Check the labels exist
```
app.kubernetes.io/name: {{ .Chart.Name }}
app.kubernetes.io/instance: {{ .Release.Name }}
app: {{ .Release.Name }}
cloudops.io.{{ $key }}: {{ $value | replace " " "-"| quote }}
```
Results:

- Api: {INSERT HERE}
- Cron: {INSERT HERE}
- Handler: {INSERT HERE}
- Ui: {INSERT HERE}

### I will Update the library charts patch versions once approved 
```
Variant API: 2.1.8 -> 2.1.9
Varaint Cron: 1.2.7 -> 1.2.8
Varaint Handler: 1.1.6 -> 1.1.7
Variant UI: 1.4.2 -> 1.4.3
```
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
