### PR TITLE
[F/CLOUD-1708] add PDB and soft nodeAffinity

### DIFF
--- a/charts/library/templates/_chart.tpl
+++ b/charts/library/templates/_chart.tpl
@@ -65,5 +65,5 @@ podAntiAffinity:
           operator: In
           values:
           - {{ .Chart.Name }}
-      topologyKey: topology.kubernetes.io/zone
+      topologyKey: kubernetes.io/hostname
 {{- end }}

--- a/charts/library/templates/_chart.tpl
+++ b/charts/library/templates/_chart.tpl
@@ -46,3 +46,24 @@ app: {{ .Release.Name }}
 cloudops.io.{{ $key }}: {{ $value | replace " " "-"| quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Pod AntiAffinity
+*/}}
+{{- define "library.chart.podAntiAffinity" -}}
+podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+        - key : app.kubernetes.io/instance
+          operator: In
+          values:
+          - {{ .Release.Name }}
+        - key : app.kubernetes.io/name
+          operator: In
+          values:
+          - {{ .Chart.Name }}
+      topologyKey: topology.kubernetes.io/zone
+{{- end }}

--- a/charts/library/templates/_poddisruptionbudget.tpl
+++ b/charts/library/templates/_poddisruptionbudget.tpl
@@ -1,0 +1,16 @@
+{{- define "library.poddisruptionbudget.tpl" }}
+---
+{{- if gt (.Values.autoscaling.minReplicas | int) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "library.chart.fullname" . }}-chart
+  labels:
+    {{- include "library.chart.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "library.chart.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.10
+version: 2.1.11-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.11-beta
+version: 2.1.11
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.11-beta](https://img.shields.io/badge/Version-2.1.11--beta-informational?style=flat-square)
+![Version: 2.1.11](https://img.shields.io/badge/Version-2.1.11-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.10](https://img.shields.io/badge/Version-2.1.10-informational?style=flat-square)
+![Version: 2.1.11-beta](https://img.shields.io/badge/Version-2.1.11--beta-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 
@@ -133,6 +133,7 @@ All possible objects created by this chart:
 | istio.ingress.public | bool | `false` | When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*. When `true`, an additional publicly accessible URL will be created. This API should be secured behind some authentication method when set to `true`. See [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress/) for more Istio details. |
 | istio.ingress.redirects | list | `[]` | Optional paths that will always redirect to internal/VPN endpoints |
 | livenessProbe | map | `{}` | Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes/) |
+| minAvailable | int | `1` | Minimum number of pods that should be available after an eviction See [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | nodeSelector | map | `{}` | Node labels for pod assignment. [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/nodeselector/) |
 | readinessProbe | map | `{}` | Indicates whether container is ready for requests. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes/) |
 | revision | string | `nil` | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |

--- a/charts/variant-api/templates/deployment.yaml
+++ b/charts/variant-api/templates/deployment.yaml
@@ -22,6 +22,31 @@ spec:
     spec:
       serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true
+      {{- if len .Values.nodeSelector }}
+      nodeSelector:
+        {{- range $key, $value := .Values.nodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      affinity:
+        {{- if len .Values.affinity }}
+          {{- range $key, $value := .Values.affinity }}
+          {{ $key }}: {{ toYaml $value | nindent 8 }}
+          {{- end }}
+        {{- else }}
+        {{- include "library.chart.podAntiAffinity" . | nindent 8 }}
+        {{- end }}
+      {{- if len .Values.tolerations }}
+      tolerations:
+        {{- range .Values.tolerations }}
+        - key: {{ required "Key is required for tolerations" .key | quote }}
+          operator: {{ .operator | default "Exists" | quote }}
+          {{- if hasKey . "value"  }}
+          value: {{ .value | quote }}
+          {{- end }}
+          effect: {{ .effect | default "NoSchedule" | quote }}
+        {{- end }}
+      {{- end }}
       ### Behold! Long explanation for why securityContext is set here:
       #
       # When the "eks.amazonaws.com/role-arn" annotation is applied to the ServiceAccount used by this Deployment, 
@@ -126,28 +151,5 @@ spec:
             {{- end }}
           {{- end }}
           envFrom: {{ include "library.container.envFrom.tpl" . | nindent 12 }}
-          {{- if len .Values.nodeSelector }}
-          nodeSelector:
-            {{- range $key, $value := .Values.nodeSelector }}
-            {{ $key }}: {{ $value }}
-            {{- end }}
-          {{- end }}
-          {{- if len .Values.affinity }}
-          affinity:
-            {{- range $key, $value := .Values.affinity }}
-            {{ $key }}: {{ toYaml $value | nindent 14 }}
-            {{- end }}
-          {{- end }}
-          {{- if len .Values.tolerations }}
-          tolerations:
-            {{- range .Values.tolerations }}
-            - key: {{ required "Key is required for tolerations" .key | quote }}
-              operator: {{ .operator | default "Exists" | quote }}
-              {{- if hasKey . "value"  }}
-              value: {{ .value | quote }}
-              {{- end }}
-              effect: {{ .effect | default "NoSchedule" | quote }}
-            {{- end }}
-          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/variant-api/templates/poddisruptionbudget.yaml
+++ b/charts/variant-api/templates/poddisruptionbudget.yaml
@@ -1,0 +1,1 @@
+{{ include "library.poddisruptionbudget.tpl" . }}

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -188,3 +188,7 @@ livenessProbe: {}
 
 # -- (map) Deployment tags
 tags: {}
+
+# -- (int) Minimum number of pods that should be available after an eviction
+# See [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+minAvailable: 1

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.9-beta
+version: 1.1.9
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.8
+version: 1.1.9-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.9-beta](https://img.shields.io/badge/Version-1.1.9--beta-informational?style=flat-square)
+![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square)
+![Version: 1.1.9-beta](https://img.shields.io/badge/Version-1.1.9--beta-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 
@@ -93,6 +93,7 @@ All possible objects created by this chart:
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/egress) and [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress) for more details. |
 | livenessProbe | map | `{}` | Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes) |
+| minAvailable | int | `1` | Minimum number of pods that should be available after an eviction See [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | nodeSelector | map | `{}` | Node labels for pod assignment [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/nodeselector) |
 | podSecurityContext.fsGroup | int | `65534` | Groups of nobody |
 | readinessProbe | map | `{}` | Indicates whether container is ready for requests. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes) |

--- a/charts/variant-handler/templates/deployment.yaml
+++ b/charts/variant-handler/templates/deployment.yaml
@@ -29,12 +29,14 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
       {{- end }}
-      {{- if len .Values.affinity }}
       affinity:
-        {{- range $key, $value := .Values.affinity }}
-        {{ $key }}: {{ toYaml $value | nindent 14 }}
+        {{- if len .Values.affinity }}
+          {{- range $key, $value := .Values.affinity }}
+          {{ $key }}: {{ toYaml $value | nindent 8 }}
+          {{- end }}
+        {{- else }}
+        {{- include "library.chart.podAntiAffinity" . | nindent 8 }}
         {{- end }}
-      {{- end }}
       {{- if len .Values.tolerations }}
       tolerations:
         {{- range .Values.tolerations }}

--- a/charts/variant-handler/templates/hpa.yaml
+++ b/charts/variant-handler/templates/hpa.yaml
@@ -27,4 +27,4 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-    {{- end }}
+{{- end }}

--- a/charts/variant-handler/templates/poddisruptionbudget.yaml
+++ b/charts/variant-handler/templates/poddisruptionbudget.yaml
@@ -1,0 +1,1 @@
+{{ include "library.poddisruptionbudget.tpl" . }}

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -148,3 +148,7 @@ livenessProbe: {}
 
 # -- (map) Deployment tags
 tags: {}
+
+# -- (int) Minimum number of pods that should be available after an eviction
+# See [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+minAvailable: 1

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.5
+version: 1.4.6-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.6-beta
+version: 1.4.6
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square)
+![Version: 1.4.6-beta](https://img.shields.io/badge/Version-1.4.6--beta-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 
@@ -126,6 +126,7 @@ All possible objects created by this chart:
 | istio.ingress.public | bool | `false` | When `false`, an internal URL will be created that will expose your application *via OpenVPN-only*. When `true`, an additional publicly accessible URL will be created. This API should be secured behind some authentication method when set to `true`. |
 | istio.ingress.redirects | list | `[]` | Optional paths that will always redirect to internal/VPN endpoints |
 | livenessProbe | map | `{}` | Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes) |
+| minAvailable | int | `1` | Minimum number of pods that should be available after an eviction See [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | nameOverride | string | `nil` | nameOverride replaces the name of the chart in the Chart.yaml file |
 | nodeSelector | map | `{}` | Node labels for pod assignment [NodeSelector](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/nodeselector) |
 | readinessProbe | map | `{}` | Indicates whether container is ready for requests. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes) |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.6-beta](https://img.shields.io/badge/Version-1.4.6--beta-informational?style=flat-square)
+![Version: 1.4.6](https://img.shields.io/badge/Version-1.4.6-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 

--- a/charts/variant-ui/templates/deployment.yaml
+++ b/charts/variant-ui/templates/deployment.yaml
@@ -24,6 +24,31 @@ spec:
     spec:
       serviceAccountName: {{ $fullName }}
       automountServiceAccountToken: true
+      {{- if len .Values.nodeSelector }}
+      nodeSelector:
+        {{- range $key, $value := .Values.nodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      affinity:
+        {{- if len .Values.affinity }}
+          {{- range $key, $value := .Values.affinity }}
+          {{ $key }}: {{ toYaml $value | nindent 8 }}
+          {{- end }}
+        {{- else }}
+        {{- include "library.chart.podAntiAffinity" . | nindent 8 }}
+        {{- end }}
+      {{- if len .Values.tolerations }}
+      tolerations:
+        {{- range .Values.tolerations }}
+        - key: {{ required "Key is required for tolerations" .key | quote }}
+          operator: {{ .operator | default "Exists" | quote }}
+          {{- if hasKey . "value"  }}
+          value: {{ .value | quote }}
+          {{- end }}
+          effect: {{ .effect | default "NoSchedule" | quote }}
+        {{- end }}
+      {{- end }}
       ### Behold! Long explanation for why securityContext is set here:
       #
       # When the "eks.amazonaws.com/role-arn" annotation is applied to the ServiceAccount used by this Deployment, 
@@ -109,28 +134,5 @@ spec:
               readOnly: true
               mountPath: {{ .Values.configMountPath }}
           envFrom: {{ include "library.container.envFrom.tpl" . | nindent 12 }}
-          {{- if len .Values.nodeSelector }}
-          nodeSelector:
-            {{- range $key, $value := .Values.nodeSelector }}
-            {{ $key }}: {{ $value }}
-            {{- end }}
-          {{- end }}
-          {{- if len .Values.affinity }}
-          affinity:
-            {{- range $key, $value := .Values.affinity }}
-            {{ $key }}: {{ toYaml $value | nindent 14 }}
-            {{- end }}
-          {{- end }}
-          {{- if len .Values.tolerations }}
-          tolerations:
-            {{- range .Values.tolerations }}
-            - key: {{ required "Key is required for tolerations" .key | quote }}
-              operator: {{ .operator | default "Exists" | quote }}
-              {{- if hasKey . "value"  }}
-              value: {{ .value | quote }}
-              {{- end }}
-              effect: {{ .effect | default "NoSchedule" | quote }}
-            {{- end }}
-          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/variant-ui/templates/poddisruptionbudget.yaml
+++ b/charts/variant-ui/templates/poddisruptionbudget.yaml
@@ -1,0 +1,1 @@
+{{ include "library.poddisruptionbudget.tpl" . }}

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -177,3 +177,7 @@ securityContext:
 
 # -- (map) Deployment tags
 tags: {}
+
+# -- (int) Minimum number of pods that should be available after an eviction
+# See [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+minAvailable: 1


### PR DESCRIPTION
# Description

Added pod disruption budget and node affinity to UI, Handler, and API charts.

[CLOUID-1708](https://drivevariant.atlassian.net/browse/CLOUD-1708)

The versions currently have the `-beta` suffix. I will bump them after the PR has been merged.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Sanity Testing

Pre reqs:
  - Utilize the test branch [tuan/1708](https://github.com/variant-inc/demo-python-flask-variant-api/tree/tuan/1708)

**NOTE** Depending upon the capacity of the nodes, there may be fewer than 4 nodes able to handle the workloads.
*During this testing, 2 of the 4 nodes had capacity.*

Test Case 1 [Negative test case for PDB]:
- Steps
  - set the `minReplicas` to 1 for .variant/deploy/<api.yaml|handler.yaml|ui.yaml>
  - commit, push, and deploy
- Result
 - No Pod Disruption Budget is created for any of the charts (check in Lens under Config > Pod Disruption Budgets)

Test Case 2 [Positive test case for PDB]:
- Steps
  - set the `minReplicas` to 2 for .variant/deploy/<api.yaml|handler.yaml|ui.yaml>
  - commit, push, and deploy
- Results
 - A Pod Disruption Budget is created for each of the charts (check in Lens under Config > Pod Disruption Budgets)

Test Case 3 [Pod Affinity 2 pods]:
- Steps
  - In Lens, edit the `HPA` located under Config for the chart by changing the `minReplicas` to 2
  - In Lens, edit the `Deployment` for the chart by changing the specs.replicas to 2 if it has not changed
- Results
  - Each pod will be scheduled on a different node 

Test Case 4 [Pod Affinity 3 pods]:
- Steps
  - In Lens, edit the `HPA` located under Config for the chart by changing the `minReplicas` to 3
  - In Lens, edit the `Deployment` for the chart by changing the specs.replicas to 3 if it has not changed
- Results
  - If 2 nodes are available, 2 pods will be on one node and 1 pod will be scheduled on a different node 

Test Case 5 [Pod Affinity 4 pods]:
- Steps
  - In Lens, edit the `HPA` located under Config for the chart by changing the `minReplicas` to 4
  - In Lens, edit the `Deployment` for the chart by changing the specs.replicas to 4 if it has not changed
- Results
  - If 2 nodes are available, 2 pods will be on one node and 2 pods will be scheduled on a different node 

Test Case 6 [Pod Affinity 5 pods]:
- Steps
  - In Lens, edit the `HPA` located under Config for the chart by changing the `minReplicas` to 5
  - In Lens, edit the `Deployment` for the chart by changing the specs.replicas to 5 if it has not changed
- Results
  - If 2 nodes are available, 3 pods will be on one node and 2 pods will be scheduled on a different node 

Test Case 7 [Pod Affinity 5 pods]:
- Steps
  - In Lens, edit the `HPA` located under Config for the chart by changing the `minReplicas` to 6
  - In Lens, edit the `Deployment` for the chart by changing the specs.replicas to 6 if it has not changed
- Results
  - If 2 nodes are available, 3 pods will be on one node and 3 pods will be scheduled on a different node 

**REPEAT TEST CASES 3-7 FOR EACH OF (API, UI, AND HANDLER)**

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
