### PR TITLE
[CLOUD-1756] set cron concurrencyPolicy to Replace

### DIFF
--- a/charts/variant-api/ci/jwt-whtitelist-values.yaml
+++ b/charts/variant-api/ci/jwt-whtitelist-values.yaml
@@ -16,7 +16,7 @@ istio:
 service:
   targetPort: 5000
 authentication:
-  enabled: true
+  enabled: false
   server: trustme.com
 authorization:
   rules:

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.10-beta
+version: 1.2.10
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.9
+version: 1.2.10-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square)
+![Version: 1.2.10-beta](https://img.shields.io/badge/Version-1.2.10--beta-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.10-beta](https://img.shields.io/badge/Version-1.2.10--beta-informational?style=flat-square)
+![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -76,6 +76,7 @@ All possible objects created by this chart:
 | awsSecrets | list | `[]` | A list of secrets to configure to make available to your API. Create your secret in AWS Secrets Manager as plain text. Full contents of this secret will be mounted as a file your application can read to /app/secrets/{name} See [AWS Secrets](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/environment_variables) for more details. |
 | configVars | map | `{}` | User defined environment variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/environment_variables) |
 | cronJob.command | list | `nil` | full path to the job script to execute. https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ |
+| cronJob.concurrencyPolicy | string | `"Replace"` | https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy |
 | cronJob.image.pullPolicy | string | `"Always"` | IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | cronJob.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |

--- a/charts/variant-cron/templates/cron.yaml
+++ b/charts/variant-cron/templates/cron.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- $labels | nindent 4 }}
 spec:
   schedule: {{  required "cronJob.schedule is required" .Values.cronJob.schedule | quote }}
-  concurrencyPolicy: Replace
+  concurrencyPolicy: {{ .Values.cronJob.concurrencyPolicy }}
   startingDeadlineSeconds: {{ .Values.cronJob.startingDeadlineSeconds  }}
   suspend: {{ .Values.cronJob.suspend }}
   successfulJobsHistoryLimit: 3

--- a/charts/variant-cron/templates/cron.yaml
+++ b/charts/variant-cron/templates/cron.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- $labels | nindent 4 }}
 spec:
   schedule: {{  required "cronJob.schedule is required" .Values.cronJob.schedule | quote }}
-  concurrencyPolicy: {{  .Values.cronJob.concurrencyPolicy  }}
+  concurrencyPolicy: Replace
   startingDeadlineSeconds: {{ .Values.cronJob.startingDeadlineSeconds  }}
   suspend: {{ .Values.cronJob.suspend }}
   successfulJobsHistoryLimit: 3

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -68,6 +68,8 @@ cronJob:
       cpu: .1
       # -- (string) Request memory
       memory: 384Mi
+  # -- (string) https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy
+  concurrencyPolicy: Replace
   # -- (map) https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}
   # -- (list) full path to the job script to execute. https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/


### PR DESCRIPTION
# Description

Allows only 1 instance of a cron job to run.

Fixes [CLOUD-1756](https://drivevariant.atlassian.net/browse/CLOUD-1756)

I will bump the variant-cron chart version from 1.2.9 -> 1.2.10 after the PR is reviewed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test branches:
https://github.com/variant-inc/dx-demo-cron/tree/t/cron-concurrencypolicy

Test Case [Single cron job allowed]:
- Steps
  - build and deploy the test branch or redeploy: https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/dx-demo-cron/deployments/releases/0.1.0-t-cron-concurren0001.35
  - open Lens or K9S, select pods in namespace `demo`, filter by `dx-demo-cron`
  - observe the pod
- Result
  - The cron schedule is every 2 minutes and the fake cron job runs for 4 minutes so a pod will be created every 2 minutes and destroy the existing pod which has not yet finished its work.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
