### PR TITLE
[CLOUD-1776] defaulting failureThreshold and periodSeconds if not sent

### DIFF
--- a/charts/library/templates/_podspec.tpl
+++ b/charts/library/templates/_podspec.tpl
@@ -86,27 +86,43 @@ spec:
           containerPort: {{ .Values.service.healthCheckPort }}
           protocol: TCP
       {{- end }}
+      {{ $failureThresholdDefault := 15 }}
+      {{ $periodSecondsDefault := 30 }}
       {{- if .Values.livenessProbe }}
-      livenessProbe: {{ .Values.livenessProbe | toYaml | nindent 12 }}
-      {{- else }}
+      livenessProbe: {{ .Values.livenessProbe | toYaml | nindent 12 -}}
+            {{- if not .Values.livenessProbe.failureThreshold }}
+            failureThreshold: {{ $failureThresholdDefault }}
+            {{- end }}
+            {{- if not .Values.livenessProbe.periodSeconds }}
+            periodSeconds: 30
+            {{- end }}
+      {{- else -}}
       {{ $port := ternary "http" "health" (empty .Values.service.healthCheckPort) }}
       livenessProbe:
         httpGet:
           path: /health
           port: {{ $port }}
         initialDelaySeconds: 10
-        periodSeconds: 10
+        periodSeconds: {{ $periodSecondsDefault }}
+        failureThreshold: {{ $failureThresholdDefault }}
       {{- end }}
       {{- if .Values.readinessProbe }}
-      readinessProbe: {{ .Values.readinessProbe | toYaml | nindent 12 }}
-      {{- else }}
+      readinessProbe: {{ .Values.readinessProbe | toYaml | nindent 12 -}}
+            {{- if not .Values.readinessProbe.failureThreshold }}
+            failureThreshold: {{ $failureThresholdDefault }}
+            {{- end }}
+            {{- if not .Values.readinessProbe.periodSeconds }}
+            periodSeconds: {{ $periodSecondsDefault }}
+            {{- end }}
+      {{- else -}}
       {{ $port := ternary "http" "health" (empty .Values.service.healthCheckPort) }}
       readinessProbe:
         httpGet:
           path: /health
           port: {{ $port }}
         initialDelaySeconds: 10
-        periodSeconds: 10
+        periodSeconds: {{ $periodSecondsDefault }}
+        failureThreshold: {{ $failureThresholdDefault }}
       {{- end }}
       resources:
       {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.14-beta
+version: 2.1.14
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.12
+version: 2.1.14-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.14-beta](https://img.shields.io/badge/Version-2.1.14--beta-informational?style=flat-square)
+![Version: 2.1.14](https://img.shields.io/badge/Version-2.1.14-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.12](https://img.shields.io/badge/Version-2.1.12-informational?style=flat-square)
+![Version: 2.1.14-beta](https://img.shields.io/badge/Version-2.1.14--beta-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.10
+version: 1.1.12-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.12-beta
+version: 1.1.12
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.12-beta](https://img.shields.io/badge/Version-1.1.12--beta-informational?style=flat-square)
+![Version: 1.1.12](https://img.shields.io/badge/Version-1.1.12-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square)
+![Version: 1.1.12-beta](https://img.shields.io/badge/Version-1.1.12--beta-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.9-beta
+version: 1.4.9
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.7
+version: 1.4.9-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.9-beta](https://img.shields.io/badge/Version-1.4.9--beta-informational?style=flat-square)
+![Version: 1.4.9](https://img.shields.io/badge/Version-1.4.9-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.7](https://img.shields.io/badge/Version-1.4.7-informational?style=flat-square)
+![Version: 1.4.9-beta](https://img.shields.io/badge/Version-1.4.9--beta-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 


### PR DESCRIPTION
# Description

Defaulting failureThreshold to 5x from normal default of 3, so it is 15.
Defaulting periodSeconds to 30 from normal default of 10.

I will bump versions after the PR is reviewed.

Fixes [CLOUD-1776](https://drivevariant.atlassian.net/browse/CLOUD-1776)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

[Test branch](https://github.com/variant-inc/demo-python-flask-variant-api/tree/tuan/test)

- Test Case 1 [Set values for each of the 3 charts and deploy]
  - Steps
    - api: send everything
    - handler: omit failureThreshold and periodSeconds
    - ui: send no probe
    - [CI build] https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2665666374
  - Results
    - api has the values for both failureThreshold and periodSeconds sent in the deployment yaml
    - https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api/deployments/releases/0.1.0-tuan-test0001.328/deployments/Deployments-41794?activeTab=taskSummary
    - handler has the default failureThreshold (15) and periodSeconds (30) set
    - https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-handler/deployments/releases/0.1.0-tuan-test0001.328/deployments/Deployments-41777?activeTab=taskSummary
    - ui has the default failureThreshold (15) and periodSeconds (30) set
    - https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-ui/deployments/releases/0.1.0-tuan-test0001.328/deployments/Deployments-41796?activeTab=taskSummary

Local chart generation unit test are attached here:
[charts-unit-tests.zip](https://github.com/variant-inc/lazy-helm-charts/files/9112074/charts-unit-tests.zip)

- Execute the attached by running `failureThresholdAndPeriodSeconds.sh <absolutePathToYourLazyHelmChartRepo>`

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
