### PR TITLE
privilege escalation false

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Charts should start at `1.0.0`. Any breaking (backwards incompatible) changes to
   <!-- markdownlint-disable-next-line MD013 -->
   * Provide the `name` [argument](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#name) argument in the `helm_release` resource
   <!-- markdownlint-disable-next-line MD013 -->
-  * According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-api` such as `schedule-adherence-api` or `driver-api`
+  * According to the [Workload Naming Conventions](https://drivevariant.atlassian.net/wiki/spaces/CLOUD/pages/1665859671/Recommended+Conventions#Workload-Naming-Conventions), this name must end with `-handler` such as `schedule-adherence-handler` or `driver-handler`
   * This will be used as the base [object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/) that will be assigned to all Kubernetes objects created by this chart
 
 * Minimum required input table

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.14
+version: 1.1.15
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.15](https://img.shields.io/badge/Version-1.1.14-informational?style=flat-square)
+![Version: 1.1.15](https://img.shields.io/badge/Version-1.1.15-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -101,7 +101,8 @@ All possible objects created by this chart:
 | replicaCount | int | `1` | replicaCount |
 | revision | string | `"abc"` | Value for a [label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) named `revision` that will be applied to all objects created by a specific chart installation. Strongly encouraged that this value corresponds to 1 of: Octopus package version, short-SHA of the commit, Octopus release version |
 | secretVars | map | `{}` | User defined secret variables are implemented here. [More Information](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/environment_variables) |
-| securityContext | map | `{}` | Security Context for containers |
+| securityContext | map | `{"allowPrivilegeEscalation":false}` | Security Context for containers |
+| securityContext.allowPrivilegeEscalation | bool | `false` | Setting it to false ensures that no child process of a container can gain more privileges than its parent |
 | service.healthCheckPath | string | `"/health"` | Health check URI, This will be used in probes to check container status |
 | service.healthCheckPort | string | `nil` | Optional port which serves a health check endpoint at `/health` Defaults to value of `service.targetPort` if not defined. |
 | service.metricsPort | string | `nil` | Optional port which serves prometheus metrics endpoint at `/metrics` Defaults to value of `service.targetPort` if not defined. |

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.14](https://img.shields.io/badge/Version-1.1.14-informational?style=flat-square)
+![Version: 1.1.15](https://img.shields.io/badge/Version-1.1.14-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -52,7 +52,7 @@ podSecurityContext:
     fsGroup: 65534
 
 # -- (map) Security Context for containers
-securityContext: {}
+securityContext: {
   # -- Runs as non root. Must use numeric User in container
   # runAsNonRoot: true
   # -- (int) Runs as numeric user
@@ -62,9 +62,10 @@ securityContext: {}
   #   drop:
   #   - ALL
   # -- (bool) Setting it to false ensures that no child process of a container can gain more privileges than its parent
-  # allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: false
   # -- (bool) Requires that containers must run with a read-only root filesystem (i.e. no writable layer)
   # readOnlyRootFilesystem: true
+}
 
 # -- replicaCount
 replicaCount: 1


### PR DESCRIPTION
# Description

Explicitly set default value for **allowPrivilegeEscalation** and set it as `false` so insight doesn't fail the deployment
Fixes [#1907](https://drivevariant.atlassian.net/browse/CLOUD-1907)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Deploy handler without set value for **allowPrivilegeEscalation**
Check it's set to `false`
[octopus](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/luka-handler/deployments/releases/0.1.0-demo-luka-2-0001.447/deployments/Deployments-43999?activeTab=taskSummary)

2. Update value to `true` in deployment yaml
Check it's set to `true`
[octopus](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/luka-handler/deployments/releases/0.1.0-demo-luka-2-0001.448/deployments/Deployments-44011?activeTab=taskSummary)

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
