### PR TITLE
update readability of notes

### DIFF
--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.21
+version: 2.1.22
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.21](https://img.shields.io/badge/Version-2.1.21-informational?style=flat-square)
+![Version: 2.1.22](https://img.shields.io/badge/Version-2.1.22-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -21,9 +21,9 @@ The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fu
 /{{ .Release.Namespace }}/{{ $fullName }}/health
 /{{ .Release.Namespace }}/{{ $fullName }}/swagger
 /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
-{{- end}}
-{{- end}}
 ======================================================
+{{- end}}
+{{- end}}
 {{- if .Values.configVars }}
 
 Config vars:

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -2,16 +2,16 @@
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- if .Values.istio.ingress }}
 You can reach the application at:
-
+.
 https://api.internal.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
-
+.
 Through VPN: https://usxpress.atlassian.net/wiki/spaces/CLOUD/pages/2486470195/How+to+configure+OpenVPN+using+SSO+to+access+USX+Variant+Resources
 ======================================================
 {{- if .Values.istio.ingress.public }}
 ....or
 https://api.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
 for public access.
-------------------------------------------------------
+.
 The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fullName }}
 {{- if .Values.istio.ingress.redirects}}
 {{- range .Values.istio.ingress.redirects }}
@@ -52,7 +52,7 @@ Accessing the pod terminal:
 Option #1
 Use tool like Lens, connect to the correct env cluster and find the pod in correct namespace: {{ $.Release.Namespace }}
 Click on it and in top right corner you'll have "Pod Shell" button which will allow you to enter pod's shell.
-------------------------------------------------------
+.
 Option #2
 Use terminal command like this:
 kubectl exec -i -t -n {{ $.Release.Namespace }} <pod name> -c {{ $fullName }} -- sh -c "clear; (bash || ash || sh)"

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -25,23 +25,20 @@ The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fu
 {{- end}}
 {{- end}}
 {{- if .Values.configVars }}
-
 Config vars:
 {{- range $key, $value := .Values.configVars }}
 {{ $key }}: {{ $value | quote }}
 {{- end }}
-======================================================
+.
 {{- end }}
 {{- if .Values.configMaps }}
-
 Config maps:
 {{- range .Values.configMaps }}
 {{ . }}
 {{- end }}
-======================================================
+.
 {{- end }}
 {{- if .Values.awsSecrets }}
-
 AWS Secrets
 {{- range .Values.awsSecrets }}
 {{ .reference }}: {{ .name }}

--- a/charts/variant-api/templates/NOTES.txt
+++ b/charts/variant-api/templates/NOTES.txt
@@ -1,17 +1,17 @@
+======================================================
 {{- $fullName := (include "chart.fullname" .) -}}
 {{- if .Values.istio.ingress }}
-
 You can reach the application at:
 
 https://api.internal.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
 
 Through VPN: https://usxpress.atlassian.net/wiki/spaces/CLOUD/pages/2486470195/How+to+configure+OpenVPN+using+SSO+to+access+USX+Variant+Resources
-
+======================================================
 {{- if .Values.istio.ingress.public }}
 ....or
 https://api.apps.{{ .Values.istio.ingress.host }}/{{ .Release.Namespace }}/{{ $fullName }}
 for public access.
-
+------------------------------------------------------
 The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fullName }}
 {{- if .Values.istio.ingress.redirects}}
 {{- range .Values.istio.ingress.redirects }}
@@ -23,39 +23,39 @@ The folowing endpoints are being redirected to /{{ $.Release.Namespace }}/{{ $fu
 /{{ .Release.Namespace }}/{{ $fullName }}/swaggerui
 {{- end}}
 {{- end}}
-
+======================================================
 {{- if .Values.configVars }}
 
 Config vars:
 {{- range $key, $value := .Values.configVars }}
 {{ $key }}: {{ $value | quote }}
 {{- end }}
+======================================================
 {{- end }}
-
 {{- if .Values.configMaps }}
 
 Config maps:
 {{- range .Values.configMaps }}
 {{ . }}
 {{- end }}
+======================================================
 {{- end }}
-
 {{- if .Values.awsSecrets }}
 
 AWS Secrets
 {{- range .Values.awsSecrets }}
 {{ .reference }}: {{ .name }}
 {{- end }}
+======================================================
 {{- end }}
-
 Accessing the pod terminal:
 Option #1
 Use tool like Lens, connect to the correct env cluster and find the pod in correct namespace: {{ $.Release.Namespace }}
 Click on it and in top right corner you'll have "Pod Shell" button which will allow you to enter pod's shell.
-
+------------------------------------------------------
 Option #2
 Use terminal command like this:
 kubectl exec -i -t -n {{ $.Release.Namespace }} <pod name> -c {{ $fullName }} -- sh -c "clear; (bash || ash || sh)"
-
+======================================================
 Checking for events and troubleshooting:
 https://backstage.apps.ops-drivevariant.com/docs/default/component/dx-docs/Troubleshooting/


### PR DESCRIPTION
# Description

We can't print empty lines in Octopus Task Log so we're updating readability of helm notes to make them less confusing.
New format will look like this:
```
======================================================
You can reach the application at:
.
https://api.internal.apps.dpl-drivevariant.com/demo/test-luka
.
Through VPN: https://usxpress.atlassian.net/wiki/spaces/CLOUD/pages/2486470195/How+to+configure+OpenVPN+using+SSO+to+access+USX+Variant+Resources
======================================================
Config vars:
PLAIN_CONFIG: "foo"
.
Config maps:
test-existing
.
AWS Secrets
rdscreds: devops-playground-rds-creds
======================================================
Accessing the pod terminal:
Option #1
Use tool like Lens, connect to the correct env cluster and find the pod in correct namespace: demo
Click on it and in top right corner you'll have "Pod Shell" button which will allow you to enter pod's shell.
.
Option #2
Use terminal command like this:
kubectl exec -i -t -n demo <pod name> -c test-luka -- sh -c "clear; (bash || ash || sh)"
======================================================
Checking for events and troubleshooting:
https://backstage.apps.ops-drivevariant.com/docs/default/component/dx-docs/Troubleshooting/
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

local dry-run of helm install
```
helm install -f .\ci\default-values.yaml test-luka -n demo . --dry-run
```

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
