### PR TITLE
remove CPU limits and increase default request

### DIFF
--- a/charts/library/templates/_podspec.tpl
+++ b/charts/library/templates/_podspec.tpl
@@ -125,7 +125,10 @@ spec:
         failureThreshold: {{ $failureThresholdDefault }}
       {{- end }}
       resources:
-      {{- toYaml .Values.deployment.resources | nindent 12 }}
+        limits:
+          memory: {{ .Values.deployment.resources.limits.memory }}
+        requests:
+          {{- toYaml .Values.deployment.resources.requests | nindent 12 }}
       env:
         - name: REVISION
           value: {{ required "revision is required" .Values.revision | quote }}

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.24-beta
+version: 2.1.24
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.24
+version: 2.1.24-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.23
+version: 2.1.24
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -123,8 +123,9 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | deployment.podAnnotations | map | `{}` | [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
+| deployment.resources.limits.cpu | int | `null` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| deployment.resources.requests.cpu | float | `0.2` | Requests CPU |
+| deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/egress/) and [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress/) for more details. |
 | istio.ingress.disableRewrite | bool | `false` | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -123,7 +123,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | deployment.podAnnotations | map | `{}` | [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
-| deployment.resources.limits.cpu | int | `null` | Limits CPU |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.23](https://img.shields.io/badge/Version-2.1.23-informational?style=flat-square)
+![Version: 2.1.24](https://img.shields.io/badge/Version-2.1.24-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 
@@ -123,9 +123,8 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | deployment.podAnnotations | map | `{}` | [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
-| deployment.resources.limits.cpu | int | `0.5` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
+| deployment.resources.requests.cpu | float | `0.2` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/egress/) and [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress/) for more details. |
 | istio.ingress.disableRewrite | bool | `false` | When `true`, the path `/{target-namespace}/{helm-release-name}` will be preserved in requests to your application, else rewritten to `/` when `false` |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.24](https://img.shields.io/badge/Version-2.1.24-informational?style=flat-square)
+![Version: 2.1.24-beta](https://img.shields.io/badge/Version-2.1.24--beta-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 
@@ -123,7 +123,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | deployment.podAnnotations | map | `{}` | [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
-| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.24-beta](https://img.shields.io/badge/Version-2.1.24--beta-informational?style=flat-square)
+![Version: 2.1.24](https://img.shields.io/badge/Version-2.1.24-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -123,7 +123,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | deployment.podAnnotations | map | `{}` | [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
+| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -123,7 +123,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | deployment.podAnnotations | map | `{}` | [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null, can't be overridden |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -81,13 +81,11 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU
-      cpu: .5
       # -- (string) Limits Memory
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .1
+      cpu: .2
       # -- (string) Request memory
       memory: 384Mi
   # -- (list) List of arguments that can be passed in the image.

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -81,7 +81,7 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU, intentionally set to null
+      # -- (int) Limits CPU, intentionally set to null, can't be overridden
       cpu: null
       # -- (string) Limits Memory
       memory: 768Mi

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -81,6 +81,8 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
+      # -- (int) Limits CPU, intentionally set to null
+      cpu: null
       # -- (string) Limits Memory
       memory: 768Mi
     requests:

--- a/charts/variant-api/values.yaml
+++ b/charts/variant-api/values.yaml
@@ -87,7 +87,7 @@ deployment:
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .2
+      cpu: .1
       # -- (string) Request memory
       memory: 384Mi
   # -- (list) List of arguments that can be passed in the image.

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.18
+version: 1.2.18-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.17
+version: 1.2.18
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.18-beta
+version: 1.2.18
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.18-beta](https://img.shields.io/badge/Version-1.2.18--beta-informational?style=flat-square)
+![Version: 1.2.18](https://img.shields.io/badge/Version-1.2.18-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -81,7 +81,7 @@ All possible objects created by this chart:
 | cronJob.image.pullPolicy | string | `"Always"` | IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | cronJob.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `null` | Limits CPU |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
 | cronJob.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | cronJob.resources.requests.cpu | float | `0.1` | Requests CPU |
 | cronJob.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -81,8 +81,9 @@ All possible objects created by this chart:
 | cronJob.image.pullPolicy | string | `"Always"` | IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | cronJob.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| deployment.resources.limits.cpu | int | `null` | Limits CPU |
 | cronJob.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| cronJob.resources.requests.cpu | float | `0.2` | Requests CPU |
+| cronJob.resources.requests.cpu | float | `0.1` | Requests CPU |
 | cronJob.resources.requests.memory | string | `"384Mi"` | Request memory |
 | cronJob.schedule | string | `nil` | Cron Style Schedule. For help check https://crontab.guru/ |
 | cronJob.suspend | bool | `false` | https://kubernetes.io/blog/2021/04/12/introducing-suspended-jobs/ |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.18](https://img.shields.io/badge/Version-1.2.18-informational?style=flat-square)
+![Version: 1.2.18-beta](https://img.shields.io/badge/Version-1.2.18--beta-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -81,7 +81,7 @@ All possible objects created by this chart:
 | cronJob.image.pullPolicy | string | `"Always"` | IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | cronJob.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null, can't be overridden |
 | cronJob.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | cronJob.resources.requests.cpu | float | `0.1` | Requests CPU |
 | cronJob.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.17](https://img.shields.io/badge/Version-1.2.17-informational?style=flat-square)
+![Version: 1.2.18](https://img.shields.io/badge/Version-1.2.18-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 
@@ -81,9 +81,8 @@ All possible objects created by this chart:
 | cronJob.image.pullPolicy | string | `"Always"` | IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | cronJob.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| cronJob.resources.limits.cpu | int | `0.5` | Limits CPU |
 | cronJob.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| cronJob.resources.requests.cpu | float | `0.1` | Requests CPU |
+| cronJob.resources.requests.cpu | float | `0.2` | Requests CPU |
 | cronJob.resources.requests.memory | string | `"384Mi"` | Request memory |
 | cronJob.schedule | string | `nil` | Cron Style Schedule. For help check https://crontab.guru/ |
 | cronJob.suspend | bool | `false` | https://kubernetes.io/blog/2021/04/12/introducing-suspended-jobs/ |

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -81,7 +81,7 @@ All possible objects created by this chart:
 | cronJob.image.pullPolicy | string | `"Always"` | IfNotPresent, Always, Never |
 | cronJob.image.tag | string | `nil` | The full URL of the image to be deployed containing the HTTP API application |
 | cronJob.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
+| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | cronJob.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | cronJob.resources.requests.cpu | float | `0.1` | Requests CPU |
 | cronJob.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-cron/ci/default-values.yaml
+++ b/charts/variant-cron/ci/default-values.yaml
@@ -23,13 +23,6 @@ cronJob:
   image:
     pullPolicy: IfNotPresent
     tag: curlimages/curl
-  resources:
-    limits:
-      cpu: 1
-      memory: 768Mi
-    requests:
-      cpu: .1
-      memory: 384Mi
   args: []
   podAnnotations: {}
   command: 

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -59,13 +59,11 @@ cronJob:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU
-      cpu: .5
       # -- (string) Limits Memory
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .1
+      cpu: .2
       # -- (string) Request memory
       memory: 384Mi
   # -- (string) https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -59,6 +59,8 @@ cronJob:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
+      # -- (int) Limits CPU, intentionally set to null
+      cpu: null
       # -- (string) Limits Memory
       memory: 768Mi
     requests:

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -65,7 +65,7 @@ cronJob:
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .2
+      cpu: .1
       # -- (string) Request memory
       memory: 384Mi
   # -- (string) https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy

--- a/charts/variant-cron/values.yaml
+++ b/charts/variant-cron/values.yaml
@@ -59,7 +59,7 @@ cronJob:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU, intentionally set to null
+      # -- (int) Limits CPU, intentionally set to null, can't be overridden
       cpu: null
       # -- (string) Limits Memory
       memory: 768Mi

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.21
+version: 1.1.21-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.21-beta
+version: 1.1.21
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.20
+version: 1.1.21
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.21](https://img.shields.io/badge/Version-1.1.21-informational?style=flat-square)
+![Version: 1.1.21-beta](https://img.shields.io/badge/Version-1.1.21--beta-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 
@@ -88,7 +88,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | The full URL of the image to be deployed containing the tag |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -88,7 +88,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | The full URL of the image to be deployed containing the tag |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `null` | Limits CPU |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.20](https://img.shields.io/badge/Version-1.1.20-informational?style=flat-square)
+![Version: 1.1.21](https://img.shields.io/badge/Version-1.1.21-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 
@@ -88,9 +88,8 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | The full URL of the image to be deployed containing the tag |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `0.5` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
+| deployment.resources.requests.cpu | float | `0.2` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/egress) and [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress) for more details. |
 | livenessProbe | map | `{}` | Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes) |

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -88,7 +88,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | The full URL of the image to be deployed containing the tag |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null, can't be overridden |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.21-beta](https://img.shields.io/badge/Version-1.1.21--beta-informational?style=flat-square)
+![Version: 1.1.21](https://img.shields.io/badge/Version-1.1.21-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -88,7 +88,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | The full URL of the image to be deployed containing the tag |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
+| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -88,8 +88,9 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `"tag"` | The full URL of the image to be deployed containing the tag |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| deployment.resources.limits.cpu | int | `null` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| deployment.resources.requests.cpu | float | `0.2` | Requests CPU |
+| deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | istio.egress | list | `[]` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [egress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/egress) and [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress) for more details. |
 | livenessProbe | map | `{}` | Indicates whether container is running. See [Probe](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/probes) |

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -91,7 +91,7 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU, intentionally set to null
+      # -- (int) Limits CPU, intentionally set to null, can't be overridden
       cpu: null
       # -- (string) Limits Memory
       memory: 768Mi

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -91,6 +91,8 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
+      # -- (int) Limits CPU, intentionally set to null
+      cpu: null
       # -- (string) Limits Memory
       memory: 768Mi
     requests:

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -97,7 +97,7 @@ deployment:
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .2
+      cpu: .1
       # -- (string) Request memory
       memory: 384Mi
   # -- (list) List of arguments that can be passed in the image.

--- a/charts/variant-handler/values.yaml
+++ b/charts/variant-handler/values.yaml
@@ -91,13 +91,11 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU
-      cpu: .5
       # -- (string) Limits Memory
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .1
+      cpu: .2
       # -- (string) Request memory
       memory: 384Mi
   # -- (list) List of arguments that can be passed in the image.

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.18
+version: 1.4.18-beta
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.18-beta
+version: 1.4.18
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.17
+version: 1.4.18
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -115,8 +115,9 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the UI web application |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
+| deployment.resources.limits.cpu | int | `null` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| deployment.resources.requests.cpu | float | `0.2` | Requests CPU |
+| deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | fullnameOverride | string | `nil` | fullnameOverride completely replaces the generated name. |
 | istio.egress | string | `nil` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress) for more Istio details. |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -115,7 +115,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the UI web application |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `null` | Limits CPU |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -115,7 +115,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the UI web application |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null, can't be overridden |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -115,7 +115,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the UI web application |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `nil` | Limits CPU |
+| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.18](https://img.shields.io/badge/Version-1.4.18-informational?style=flat-square)
+![Version: 1.4.18-beta](https://img.shields.io/badge/Version-1.4.18--beta-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 
@@ -115,7 +115,7 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the UI web application |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| cronJob.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
+| deployment.resources.limits.cpu | int | `nil` | Limits CPU, intentionally set to null |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
 | deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.17](https://img.shields.io/badge/Version-1.4.17-informational?style=flat-square)
+![Version: 1.4.18](https://img.shields.io/badge/Version-1.4.18-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 
@@ -115,9 +115,8 @@ All possible objects created by this chart:
 | deployment.image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
 | deployment.image.tag | string | `nil` | The full URL of the image to be deployed containing the UI web application |
 | deployment.podAnnotations | map | `{}` | https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
-| deployment.resources.limits.cpu | int | `0.5` | Limits CPU |
 | deployment.resources.limits.memory | string | `"768Mi"` | Limits Memory |
-| deployment.resources.requests.cpu | float | `0.1` | Requests CPU |
+| deployment.resources.requests.cpu | float | `0.2` | Requests CPU |
 | deployment.resources.requests.memory | string | `"384Mi"` | Request memory |
 | fullnameOverride | string | `nil` | fullnameOverride completely replaces the generated name. |
 | istio.egress | string | `nil` | A whitelist of external services that your API requires connection to. The whitelist applies to the entire namespace in which this chart is installed. [These services](https://github.com/variant-inc/iaac-eks/blob/master/scripts/istio/service-entries.eps#L8) are globally whitelisted and do not require declaration. See [Ingress](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Apps/Common/ingress) for more Istio details. |

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.18-beta](https://img.shields.io/badge/Version-1.4.18--beta-informational?style=flat-square)
+![Version: 1.4.18](https://img.shields.io/badge/Version-1.4.18-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -90,13 +90,11 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU
-      cpu: .5
       # -- (string) Limits Memory
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .1
+      cpu: .2
       # -- (string) Request memory
       memory: 384Mi
   # -- (list) List of arguments that can be passed in the image.

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -90,7 +90,7 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
-      # -- (int) Limits CPU, intentionally set to null
+      # -- (int) Limits CPU, intentionally set to null, can't be overridden
       cpu: null
       # -- (string) Limits Memory
       memory: 768Mi

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -90,6 +90,8 @@ deployment:
   # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     limits:
+      # -- (int) Limits CPU, intentionally set to null
+      cpu: null
       # -- (string) Limits Memory
       memory: 768Mi
     requests:

--- a/charts/variant-ui/values.yaml
+++ b/charts/variant-ui/values.yaml
@@ -96,7 +96,7 @@ deployment:
       memory: 768Mi
     requests:
       # -- (float) Requests CPU
-      cpu: .2
+      cpu: .1
       # -- (string) Request memory
       memory: 384Mi
   # -- (list) List of arguments that can be passed in the image.


### PR DESCRIPTION
# Description

Removes CPU limits as we are using CPU request on all resources.
Increase default CPU request to 0.2

Fixes [#2011](https://drivevariant.atlassian.net/browse/CLOUD-2011)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
### Test 1
Locally ran helm install command.
```
helm install -f .\ci\default-values.yaml test-luka -n demo .
```
Verified there are no limits on CPU and that default requests is 200m.

### Test 2
Deploy beta version of charts
Upgrade existing release of demo app
Verify there are no more limits on CPU

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
