### PR TITLE
changes on provisioner

### DIFF
--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.19
+version: 1.2.20
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -42,7 +42,7 @@ A Helm chart for Istio Objects
     # Set to true to create custom nodes. Default is false
     create: true
     # EC2 Instance type for your custom node if you want to specify it.
-    instanceType: r5.xlarge
+    instanceType: r6a.xlarge
     # If nil, the feature is disabled, nodes will never expire
     ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
     # If nil, the feature is disabled, nodes will never scale down due to low utilization. Default 30 minutes

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.19](https://img.shields.io/badge/Version-1.2.19-informational?style=flat-square)
+![Version: 1.2.20](https://img.shields.io/badge/Version-1.2.20-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 
@@ -41,7 +41,7 @@ A Helm chart for Istio Objects
   node:
     # Set to true to create custom nodes. Default is false
     create: true
-    # EC2 Instance type for your custom node. Default is r5.xlarge
+    # EC2 Instance type for your custom node if you want to specify it.
     instanceType: r5.xlarge
     # If nil, the feature is disabled, nodes will never expire
     ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;

--- a/charts/variant-cron/README.md.gotmpl
+++ b/charts/variant-cron/README.md.gotmpl
@@ -43,7 +43,7 @@
   node:
     # Set to true to create custom nodes. Default is false
     create: true
-    # EC2 Instance type for your custom node. Default is r5.xlarge
+    # EC2 Instance type for your custom node if you want to specify it.
     instanceType: r5.xlarge
     # If nil, the feature is disabled, nodes will never expire
     ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;

--- a/charts/variant-cron/README.md.gotmpl
+++ b/charts/variant-cron/README.md.gotmpl
@@ -44,7 +44,7 @@
     # Set to true to create custom nodes. Default is false
     create: true
     # EC2 Instance type for your custom node if you want to specify it.
-    instanceType: r5.xlarge
+    instanceType: r6a.xlarge
     # If nil, the feature is disabled, nodes will never expire
     ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
     # If nil, the feature is disabled, nodes will never scale down due to low utilization. Default 30 minutes

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -59,12 +59,12 @@ template:
     serviceAccountName: {{ $fullName }}
     automountServiceAccountToken: true
     nodeSelector:
-    {{- if .Values.node.instanceType }}
+    {{- if .Values.node.create }}
+      karpenter.sh/namespace: {{ .Release.Namespace }}
+      {{- if .Values.node.instanceType }}
       node.kubernetes.io/instance-type: {{ .Values.node.instanceType | quote }}
-    {{- end }}
-      {{- range $key, $value := .Values.nodeSelector }}
-      {{ $key }}: {{ $value }}
       {{- end }}
+    {{- end }}
     {{- if len .Values.affinity }}
     affinity:
       {{- range $key, $value := .Values.affinity }}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -60,7 +60,7 @@ template:
     automountServiceAccountToken: true
     nodeSelector:
     {{- if .Values.node.create }}
-      karpenter/namespace: {{ .Release.Namespace }}
+      cloudops.io/namespace: {{ .Release.Namespace }}
       {{- if .Values.node.instanceType }}
       node.kubernetes.io/instance-type: {{ .Values.node.instanceType | quote }}
       {{- end }}

--- a/charts/variant-cron/templates/_jobspec.yaml
+++ b/charts/variant-cron/templates/_jobspec.yaml
@@ -60,7 +60,7 @@ template:
     automountServiceAccountToken: true
     nodeSelector:
     {{- if .Values.node.create }}
-      karpenter.sh/namespace: {{ .Release.Namespace }}
+      karpenter/namespace: {{ .Release.Namespace }}
       {{- if .Values.node.instanceType }}
       node.kubernetes.io/instance-type: {{ .Values.node.instanceType | quote }}
       {{- end }}
@@ -72,7 +72,7 @@ template:
       {{- end }}
     {{- end }}
     tolerations:
-    {{- if .Values.node.instanceType }}
+    {{- if .Values.node.create }}
       - key: "namespace"
         value: {{ .Release.Namespace | quote }}
         operator: "Equal"

--- a/charts/variant-cron/templates/provisioner.yaml
+++ b/charts/variant-cron/templates/provisioner.yaml
@@ -28,7 +28,7 @@ spec:
     {{- range $key, $value := .Values.nodeSelector }}
     {{ $key }}: {{ $value }}
     {{- end }}
-    karpenter.sh/namespace: {{ .Release.Namespace }}
+    karpenter/namespace: {{ .Release.Namespace }}
 
   requirements:
     - key: "karpenter.sh/capacity-type"

--- a/charts/variant-cron/templates/provisioner.yaml
+++ b/charts/variant-cron/templates/provisioner.yaml
@@ -28,7 +28,7 @@ spec:
     {{- range $key, $value := .Values.nodeSelector }}
     {{ $key }}: {{ $value }}
     {{- end }}
-    karpenter/namespace: {{ .Release.Namespace }}
+    cloudops.io/namespace: {{ .Release.Namespace }}
 
   requirements:
     - key: "karpenter.sh/capacity-type"

--- a/charts/variant-cron/templates/provisioner.yaml
+++ b/charts/variant-cron/templates/provisioner.yaml
@@ -32,9 +32,9 @@ spec:
 
   requirements:
     - key: "karpenter.sh/capacity-type"
-    operator: In
-    values:
-      - on-demand
+      operator: In
+      values:
+        - on-demand
     - key: "kubernetes.io/arch"
       operator: In
       values:

--- a/charts/variant-cron/templates/provisioner.yaml
+++ b/charts/variant-cron/templates/provisioner.yaml
@@ -39,7 +39,7 @@ spec:
       operator: In
       values:
         - amd64
-    {{ -if .Values.node.instanceType }}
+    {{- if .Values.node.instanceType }}
     - key: "node.kubernetes.io/instance-type"
       operator: In
       values: [{{ .Values.node.instanceType | quote }}]

--- a/charts/variant-cron/templates/provisioner.yaml
+++ b/charts/variant-cron/templates/provisioner.yaml
@@ -28,11 +28,22 @@ spec:
     {{- range $key, $value := .Values.nodeSelector }}
     {{ $key }}: {{ $value }}
     {{- end }}
+    karpenter.sh/namespace: {{ .Release.Namespace }}
 
   requirements:
+    - key: "karpenter.sh/capacity-type"
+    operator: In
+    values:
+      - on-demand
+    - key: "kubernetes.io/arch"
+      operator: In
+      values:
+        - amd64
+    {{ -if .Values.node.instanceType }}
     - key: "node.kubernetes.io/instance-type"
       operator: In
       values: [{{ .Values.node.instanceType | quote }}]
+    {{- end }}
   # These fields vary per cloud provider, see your cloud provider specific documentation
   provider:
     blockDeviceMappings:


### PR DESCRIPTION
# Description

Update variant-cron chart to make instance type optional in case we need nodes created by karpenter.
Allow usage of any nodes created by karpenter provisioner in same namespace.

Fixes [#2005](https://drivevariant.atlassian.net/browse/CLOUD-2005)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by locally running helm install with different values in `node` section.
### Test 1
```
node:
  create: false
```
Verify pods get scheduled on app nodes.

### Test 2
```
node:
  create: true
```
Verify that new node get's created based on karpenter provisioner configuration and pods get scheduled on that node.

### Test 3
```
node:
  create: true
  instanceType: t3a.medium
```
Verify that new node of specified instance type get's created based on karpenter provisioner configuration and pods get scheduled on that node.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
