### PR TITLE
fix url not showing in variant-ui

### DIFF
--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.19
+version: 1.4.20
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.19](https://img.shields.io/badge/Version-1.4.19-informational?style=flat-square)
+![Version: 1.4.20](https://img.shields.io/badge/Version-1.4.20-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 

--- a/charts/variant-ui/templates/NOTES.txt
+++ b/charts/variant-ui/templates/NOTES.txt
@@ -1,13 +1,14 @@
 ======================================================
 {{- $fullName := (include "chart.fullname" .) -}}
-{{- if .Values.ingress }}
+{{- if .Values.istio.ingress }}
 You can reach the application at the following hosts:
 .
-{{- range .Values.istio.ingress.hosts }}
-- https://{{ tpl .url $ | quote }}
+Through VPN: https://{{ $fullName }}.internal.apps.{{ .Values.istio.ingress.host }}
+{{- if .Values.istio.ingress.public }}
+Public: https://{{ $fullName }}.apps.{{ .Values.istio.ingress.host }}
 {{- end }}
 .
-Make sure that the hosts added have a proper certificate in the EKS cluster
+VPN setup: https://usxpress.atlassian.net/wiki/spaces/CLOUD/pages/2486470195/How+to+configure+OpenVPN+using+SSO+to+access+USX+Variant+Resources
 ======================================================
 {{- end}}
 Mount path for configVars JSON file:


### PR DESCRIPTION
# Description

Noticed that UI char doesn't show URLs in Notes output

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally rendered notes without deployment or ommit --dry-run to deploy and verify.

```
helm install -f .\ci\default-values.yaml test-luka -n demo . --dry-run
```

in .\ci\defautl-values.yaml
only private URL
```
istio:
  enabled: true
  ingress:
    host: dpl-drivevariant.com
```
output:
```
NOTES:
======================================================
You can reach the application at the following hosts:
.
Through VPN: https://test-luka.internal.apps.dpl-drivevariant.com
.
VPN setup: https://usxpress.atlassian.net/wiki/spaces/CLOUD/pages/2486470195/How+to+configure+OpenVPN+using+SSO+to+access+USX+Variant+Resources
```

public URL:
```
istio:
  enabled: true
  ingress:
    host: dpl-drivevariant.com
  public: true
```
output
```
NOTES:
======================================================
You can reach the application at the following hosts:
.
Through VPN: https://test-luka.internal.apps.dpl-drivevariant.com
Public: https://test-luka.apps.dpl-drivevariant.com
.
VPN setup: https://usxpress.atlassian.net/wiki/spaces/CLOUD/pages/2486470195/How+to+configure+OpenVPN+using+SSO+to+access+USX+Variant+Resources
```

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
