### PR TITLE
fix name for service entry ports

### DIFF
--- a/charts/library/templates/_service-entry.tpl
+++ b/charts/library/templates/_service-entry.tpl
@@ -37,7 +37,7 @@ spec:
   ports:
     {{- range .ports }}
     - number: {{ .number }}
-      name: {{ .protocol | quote | lower }}
+      name: {{ printf "%s-%d" .protocol ( .number | int ) | quote | lower }}
       protocol: {{ .protocol | quote | upper }}
     {{- end }}
   resolution: {{ .resolution | default "DNS" }}

--- a/charts/variant-api/Chart.yaml
+++ b/charts/variant-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-api
 description: A Helm chart for APIs to Variant clusters
 
-version: 2.1.28
+version: 2.1.29
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-api/README.md
+++ b/charts/variant-api/README.md
@@ -1,6 +1,6 @@
 # Variant API Helm Chart
 
-![Version: 2.1.28](https://img.shields.io/badge/Version-2.1.28-informational?style=flat-square)
+![Version: 2.1.29](https://img.shields.io/badge/Version-2.1.29-informational?style=flat-square)
 
 A Helm chart for APIs to Variant clusters
 

--- a/charts/variant-cron/Chart.yaml
+++ b/charts/variant-cron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-cron
 description: A Helm chart for Istio Objects
 
-version: 1.2.24
+version: 1.2.25
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-cron/README.md
+++ b/charts/variant-cron/README.md
@@ -1,6 +1,6 @@
 # Variant CronJob Helm Chart
 
-![Version: 1.2.24](https://img.shields.io/badge/Version-1.2.24-informational?style=flat-square)
+![Version: 1.2.25](https://img.shields.io/badge/Version-1.2.25-informational?style=flat-square)
 
 A Helm chart for Istio Objects
 

--- a/charts/variant-handler/Chart.yaml
+++ b/charts/variant-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-handler
 description: A Helm chart for kubernetes handler
 
-version: 1.1.24
+version: 1.1.25
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-handler/README.md
+++ b/charts/variant-handler/README.md
@@ -1,6 +1,6 @@
 # Variant Handler Helm Chart
 
-![Version: 1.1.24](https://img.shields.io/badge/Version-1.1.24-informational?style=flat-square)
+![Version: 1.1.25](https://img.shields.io/badge/Version-1.1.25-informational?style=flat-square)
 
 A Helm chart for kubernetes handler
 

--- a/charts/variant-ui/Chart.yaml
+++ b/charts/variant-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: variant-ui
 description: A Helm chart for a web UI configuration
 
-version: 1.4.24
+version: 1.4.25
 
 kubeVersion: "^1.7.1-0"
 home: https://www.drivevariant.com/

--- a/charts/variant-ui/README.md
+++ b/charts/variant-ui/README.md
@@ -1,6 +1,6 @@
 # Variant UI Helm Chart
 
-![Version: 1.4.24](https://img.shields.io/badge/Version-1.4.24-informational?style=flat-square)
+![Version: 1.4.25](https://img.shields.io/badge/Version-1.4.25-informational?style=flat-square)
 
 A Helm chart for a web UI configuration
 


### PR DESCRIPTION
# Description

Minor fix for service entry ports name to include port together with protocol.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
### Original names
- in charts/variant-api/ci/default-values.yaml add egress to istio configuration
```
istio:
  enabled: true
  ingress:
    host: dpl-drivevariant.com
  egress:
    - name: test
      hosts:
        - test.com
      ports:
        - number: 443
          protocol: HTTPS
      resolution: DNS
```
- locally run helm install dry run
```
cd charts/variant-api
helm dependecy update
helm install -f .\ci\default-values.yaml test-luka -n demo . --dry-run
```
- verify in output that ServiceEntry ports have name based only on <protocol>
```
---
# Source: variant-api/templates/service-entry.yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: test-luka-test
  labels:
    helm.sh/chart: variant-api-2.1.28
    app.kubernetes.io/name: variant-api
    app.kubernetes.io/instance: test-luka
    app.kubernetes.io/managed-by: Helm
    revision: "testing"
    cloudops.io.octopus/environment: "dev"
    cloudops.io.octopus/pace: "default"
    cloudops.io.octopus/project: "test"
    cloudops.io.octopus/project_group: "default-group"
    cloudops.io.octopus/release_channel: "test1"
    cloudops.io.owner: "devops"
    cloudops.io.purpose: "test"
    cloudops.io.team: "devops"
spec:
  hosts:
    - "test.com"
  exportTo:
    - "."
  location: MESH_EXTERNAL
  ports:
    - number: 443
      name: "https"
      protocol: "HTTPS"
  resolution: DNS
---
```

### Updated name
- checkout this branch
- locally run helm install dry run
```
cd charts/variant-api
helm dependecy update
helm install -f .\ci\default-values.yaml test-luka -n demo . --dry-run
```
- verify in output that ServiceEntry ports have name based on <protocol>-<port>
```
---
# Source: variant-api/templates/service-entry.yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: test-luka-test
  labels:
    helm.sh/chart: variant-api-2.1.28
    app.kubernetes.io/name: variant-api
    app.kubernetes.io/instance: test-luka
    app.kubernetes.io/managed-by: Helm
    revision: "testing"
    cloudops.io.octopus/environment: "dev"
    cloudops.io.octopus/pace: "default"
    cloudops.io.octopus/project: "test"
    cloudops.io.octopus/project_group: "default-group"
    cloudops.io.octopus/release_channel: "test1"
    cloudops.io.owner: "devops"
    cloudops.io.purpose: "test"
    cloudops.io.team: "devops"
spec:
  hosts:
    - "test.com"
  exportTo:
    - "."
  location: MESH_EXTERNAL
  ports:
    - number: 443
      name: "https-443"
      protocol: "HTTPS"
  resolution: DNS
---
```


- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
