### PR TITLE
feature: pdb maxunavailable when replica eq 1

### DIFF
--- a/charts/library/templates/_poddisruptionbudget.tpl
+++ b/charts/library/templates/_poddisruptionbudget.tpl
@@ -1,6 +1,5 @@
 {{- define "library.poddisruptionbudget.tpl" }}
 ---
-{{- if gt (.Values.autoscaling.minReplicas | int) 1 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,9 +7,12 @@ metadata:
   labels:
     {{- include "library.chart.labels" . | nindent 4 }}
 spec:
+  {{- if eq (.Values.autoscaling.minReplicas | int) 1 }}
+  maxUnavailable: 0
+  {{ else }}
   minAvailable: {{ .Values.minAvailable }}
+  {{ end }}
   selector:
     matchLabels:
       {{- include "library.chart.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

Set maxUnavailable to 0 on PDB when minReplicas set to 1.

Fixes [CLOUD-2261](https://usxpress.atlassian.net/browse/CLOUD-2261)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Running helm install locally.
```
helm install -f .\ci\default-values.yaml luka-test-pdb -n demo .
```

autoscaling.minReplicas value set to 2
![image](https://github.com/variant-inc/lazy-helm-charts/assets/63529189/745f47d7-48de-401c-a743-70a5a62f0b3d)
![image](https://github.com/variant-inc/lazy-helm-charts/assets/63529189/9e64b5c6-8ad2-4bb3-82fd-189903a3a79e)

autoscaling.minReplicas value set to 1
![image](https://github.com/variant-inc/lazy-helm-charts/assets/63529189/221985ae-d0d5-40ea-85db-4f521ee6888b)
![image](https://github.com/variant-inc/lazy-helm-charts/assets/63529189/2f61f036-520d-49d8-96bd-e7245e5ece7f)


- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[CLOUD-2261]: https://usxpress.atlassian.net/browse/CLOUD-2261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ